### PR TITLE
Make OAS_PATH default to the current directory and remove appended path

### DIFF
--- a/lib/nexmo/oas/renderer/app.rb
+++ b/lib/nexmo/oas/renderer/app.rb
@@ -19,8 +19,6 @@ require_relative'./lib/core_ext/string'
 
 require 'dotenv/load'
 
-Dotenv.require_keys('OAS_PATH')
-
 module Nexmo
   module OAS
     module Renderer
@@ -35,7 +33,7 @@ module Nexmo
 
         set :mustermann_opts, { type: :rails }
         set :show_exceptions, :after_handler
-        set :oas_path, ENV['OAS_PATH']
+        set :oas_path, (ENV['OAS_PATH'] || '.')
 
         helpers do
           include Helpers::Render

--- a/lib/nexmo/oas/renderer/filters/code_snippet.rb
+++ b/lib/nexmo/oas/renderer/filters/code_snippet.rb
@@ -70,7 +70,7 @@ module Nexmo
           end
 
           def generate_code_block(language, input, unindent)
-            filename = "#{API.oas_path}/#{input['source']}"
+            filename = input['source']
             return '' unless input
             raise "CodeSnippetFilter - Could not load #{filename} for language #{language}" unless File.exist?(filename)
 

--- a/lib/nexmo/oas/renderer/filters/code_snippets.rb
+++ b/lib/nexmo/oas/renderer/filters/code_snippets.rb
@@ -84,7 +84,7 @@ module Nexmo
           end
 
           def content_from_source
-            source_path = "#{API.oas_path}/#{@config['source']}/*.yml"
+            source_path = "#{@config['source']}/*.yml"
 
             files = Dir[source_path]
             raise "No .yml files found for #{@config['source']} code snippets" if files.empty?

--- a/lib/nexmo/oas/renderer/filters/modal.rb
+++ b/lib/nexmo/oas/renderer/filters/modal.rb
@@ -13,7 +13,7 @@ module Nexmo
             end
 
             modals = modals.map do |modal|
-              filename = "#{API.oas_path}/#{modal[:document]}"
+              filename = modal[:document]
               raise "Could not find modal #{filename}" unless File.exist? filename
 
               document = File.read(filename)

--- a/lib/nexmo/oas/renderer/filters/partial.rb
+++ b/lib/nexmo/oas/renderer/filters/partial.rb
@@ -6,7 +6,7 @@ module Nexmo
           def call(input)
             input.gsub(/```partial(.+?)```/m) do |_s|
               config = YAML.safe_load($1)
-              content = File.read("#{API.oas_path}/#{config['source']}")
+              content = File.read(config['source'])
 
               active = options[:code_language] ? options[:code_language].key == config['platform'] : false
 

--- a/lib/nexmo/oas/renderer/filters/tab.rb
+++ b/lib/nexmo/oas/renderer/filters/tab.rb
@@ -126,7 +126,7 @@ module Nexmo
           end
 
           def content_from_source
-            source_path = "#{API.oas_path}/#{@config['source']}"
+            source_path = @config['source']
             source_path += '/*' if tabbed_code_examples?
             source_path += '/*.md' if tabbed_content?
 
@@ -160,7 +160,7 @@ module Nexmo
 
           def content_from_tabs
             @config['tabs'].map do |title, config|
-              file_path = "#{API.oas_path}/#{config['source']}"
+              file_path = config['source']
               raise "Could not find content_from_tabs file: #{config['source']}" unless File.exist? file_path
               source = File.read(file_path)
 

--- a/lib/nexmo/oas/renderer/models/code_snippet.rb
+++ b/lib/nexmo/oas/renderer/models/code_snippet.rb
@@ -66,7 +66,7 @@ module Nexmo
           end
 
           def self.origin
-            "#{API.oas_path}/_documentation"
+            "_documentation"
           end
         end
       end

--- a/lib/nexmo/oas/renderer/models/tutorial.rb
+++ b/lib/nexmo/oas/renderer/models/tutorial.rb
@@ -51,7 +51,7 @@ module Nexmo
           end
 
           def self.origin
-            Pathname.new("#{API.oas_path}/_tutorials")
+            Pathname.new("_tutorials")
           end
 
           def self.all

--- a/lib/nexmo/oas/renderer/presenters/api_specification.rb
+++ b/lib/nexmo/oas/renderer/presenters/api_specification.rb
@@ -17,7 +17,7 @@ module Nexmo
           end
 
           def document
-            @document ||= File.read("#{API.oas_path}/#{document_path}")
+            @document ||= File.read(document_path)
           end
 
           def frontmatter

--- a/lib/nexmo/oas/renderer/presenters/open_api_specification.rb
+++ b/lib/nexmo/oas/renderer/presenters/open_api_specification.rb
@@ -28,28 +28,28 @@ module Nexmo
           end
 
           def initialization?
-            File.file? "#{API.oas_path}/_open_api/initialization/#{@definition_name}.md"
+            File.file? "#{API.oas_path}/../initialization/#{@definition_name}.md"
           end
 
           def initialization_content
             @initialization_content ||= MarkdownPipeline.new.call(
-              File.read("#{API.oas_path}/_open_api/initialization/#{@definition_name}.md")
+              File.read("#{API.oas_path}/../initialization/#{@definition_name}.md")
             ) if initialization?
           end
 
           def initialization_config
             @initialization_config ||= YAML.safe_load(
-              File.read("#{API.oas_path}/_open_api/initialization/#{@definition_name}.md")
+              File.read("#{API.oas_path}/../initialization/#{@definition_name}.md")
             ) if initialization?
           end
 
           def errors?
-            File.file? "#{API.oas_path}/_open_api/errors/#{@definition_name}.md"
+              File.exist?("#{API.oas_path}/../errors/#{@definition_name}.md")
           end
 
           def definition_errors
             @definition_errors ||= MarkdownPipeline.new.call(
-              File.read("#{API.oas_path}/_open_api/errors/#{@definition_name}.md")
+              File.read("#{API.oas_path}/../errors/#{@definition_name}.md")
             ) if errors?
           end
 

--- a/lib/nexmo/oas/renderer/presenters/versions.rb
+++ b/lib/nexmo/oas/renderer/presenters/versions.rb
@@ -25,7 +25,7 @@ module Nexmo
             @available_versions ||= begin
                                       versions = Constraints::OpenApi.find_all_versions(base_name)
                                       # Add in anything in the old /_api folder
-                                      if File.exist?("#{API.oas_path}/_api/#{base_name}.md")
+                                      if File.exist?("_api/#{base_name}.md")
                                         versions.push({ 'version' => '1', 'name' => base_name })
                                       end
 

--- a/lib/nexmo/oas/renderer/services/open_api_definition_resolver.rb
+++ b/lib/nexmo/oas/renderer/services/open_api_definition_resolver.rb
@@ -11,7 +11,7 @@ module Nexmo
 
           return resolve(path) if path
 
-          raise "Could not find definition '#{name}'"
+          raise "Could not find definition '#{name}' in '#{API.oas_path}'"
         end
 
         def self.paths(name)
@@ -21,7 +21,7 @@ module Nexmo
         end
 
         def self.path(name, format)
-          "#{API.oas_path}/_open_api/api_specs/definitions/#{name}.#{format}"
+          "#{API.oas_path}/definitions/#{name}.#{format}"
         end
 
         def self.resolve(path)


### PR DESCRIPTION
Previously we added _open_api/api_specs to OAS_PATH, but this makes the
gem difficult to use locally. This PR removes this requirement and Nexmo
Developer will set an OAS_PATH of _open_api/api_specs.

This allows users to run `nexmo-oas-renderer` locally in the
api-specification repo and have the endpoint rendered as expected. This
does not include any errors as they are provided in `errors.md` in the
Nexmo Developer project, and will be addressed in a future PR