### PR TITLE
Add OAS index page to list available definitions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-OAS_PATH='../nexmo-developer'
+OAS_PATH='../api-specification'
+OAS_CI=true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install the gem:
 $ gem install nexmo-oas-renderer
 ```
 
-And simply run the executable:
+And simply run the executable with the corresponding env variables set (see [Note](#note)):
 ``` shell
 $ nexmo-oas-renderer
 ```
@@ -64,7 +64,8 @@ $ cp .env.example .env
 and assign values to the corresponding variables.
 
 #### Note
-The app won't boot if the env variable `OAS_PATH` is not set. This variable indicates the path to the documents that will be rendered.
+The env variable `OAS_PATH` indicates the path to the documents that will be rendered.
+Set `OAS_CI` to true to treat all the OAS docs under `OAS_PATH` as valid.
 
 ## Contributing
 We ❤️ contributions from everyone! [Bug reports](https://github.com/Nexmo/nexmo-oas-renderer/issues), [bug fixes](https://github.com/Nexmo/nexmo-oas-renderer/pulls) and feedback on the library is always appreciated. Look at the [Contributor Guidelines](https://github.com/Nexmo/nexmo-oas-renderer/blob/master/CONTRIBUTING.md) for more information and please follow the [GitHub Flow](https://guides.github.com/introduction/flow/index.html).

--- a/lib/nexmo/oas/renderer/app.rb
+++ b/lib/nexmo/oas/renderer/app.rb
@@ -70,6 +70,16 @@ module Nexmo
           not_found erb :'static/404', layout: layout
         end
 
+        unless defined?(NexmoDeveloper::Application)
+          get '/' do
+            prefix = "#{API.oas_path}definitions"
+            @definitions = Dir.glob("#{prefix}/**/*.yml").map do |d|
+              d.gsub("#{prefix}/", '').gsub('.yml', '')
+            end.sort.reject { |d| d.include? 'common/' }
+            erb :'api/index', layout: false
+          end
+        end
+
         get '(/api)/*definition' do
           check_redirect!
 

--- a/lib/nexmo/oas/renderer/views/api/index.erb
+++ b/lib/nexmo/oas/renderer/views/api/index.erb
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <%= erb :'layouts/_head' %>
+
+  <body class="Nxd-template">
+    <main class="Vlt-main Vlt-main--light Nxd-main" tabindex="2">
+      <div class="Vlt-card" id="primary-content">
+        <h1>Choose a definition</h1>
+        <ul class="Vlt-list Vlt-list--simple">
+        <% @definitions.each do |d| %>
+          <li><a href="<%= d %>"><%= d %></a></li>
+        <% end %>
+        </ul>
+      </div>
+    </main>
+
+    <%= erb :"layouts/_javascripts" %>
+  </body>
+</html>


### PR DESCRIPTION
Adds a way to choose your definition on the index page when not mounted inside NDP

![Screen Shot 2019-06-18 at 22 54 02](https://user-images.githubusercontent.com/59130/59722668-280a1600-921c-11e9-873f-3edacd14c1c9.png)
