### PR TITLE
If there's a response description but no schema, use that in the output

### DIFF
--- a/lib/nexmo/oas/renderer/views/open_api/_endpoint.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_endpoint.erb
@@ -141,11 +141,12 @@
               <% end %>
             </div>
           <% end %>
-        </div>
 
         <% if response.code == '204' || response.formats.empty? %>
-          <pre class="highlight"><code>No content</code></pre>
+          <% content = response.description ? response.description : 'No content' %>
+          <pre class="highlight"><code><%= content %></code></pre>
         <% end %>
+        </div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
Also fixes a bug with collapsible accordians when there is no schema
available