### PR TITLE
Fix links to volta's symbols.

### DIFF
--- a/lib/nexmo/oas/renderer/filters/external_link.rb
+++ b/lib/nexmo/oas/renderer/filters/external_link.rb
@@ -11,7 +11,7 @@ module Nexmo
                 link['target'] = '_blank'
                 if link.css('svg').empty?
                   link.add_child <<~HEREDOC
-                    &nbsp;<svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-blue-dark"><use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-open"></use></svg>
+                    &nbsp;<svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-blue-dark"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-open"></use></svg>
                   HEREDOC
                 end
               end

--- a/lib/nexmo/oas/renderer/filters/heading.rb
+++ b/lib/nexmo/oas/renderer/filters/heading.rb
@@ -21,7 +21,7 @@ module Nexmo
 
               heading.prepend_child <<~HEREDOC
                 <a href="##{parameterized_heading}" class="heading-permalink">
-                  <svg class="Vlt-grey"><use xlink:href=\"/assets/symbol/volta-icons.svg#Vlt-icon-link\" /></svg>
+                  <svg class="Vlt-grey"><use xlink:href=\"/symbol/volta-icons.svg#Vlt-icon-link\" /></svg>
                 </a>
               HEREDOC
             end

--- a/lib/nexmo/oas/renderer/filters/icon.rb
+++ b/lib/nexmo/oas/renderer/filters/icon.rb
@@ -4,12 +4,12 @@ module Nexmo
       module Filters
         class Icon < Banzai::Filter
           def call(input)
-            input.gsub!('✅', '<svg class="Vlt-green Vlt-icon Vlt-icon--small"><use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-check" /></svg>')
-            input.gsub!('❌', '<svg class="Vlt-red Vlt-icon Vlt-icon--small"><use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-cross" /></svg>')
+            input.gsub!('✅', '<svg class="Vlt-green Vlt-icon Vlt-icon--small"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-check" /></svg>')
+            input.gsub!('❌', '<svg class="Vlt-red Vlt-icon Vlt-icon--small"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-cross" /></svg>')
 
             input.gsub!(/\[icon="(.+?)"\]/) do
               <<~HEREDOC
-                <svg class="Vlt-green Vlt-icon Vlt-icon--small"><use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-#{$1}" /></svg>
+                <svg class="Vlt-green Vlt-icon Vlt-icon--small"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-#{$1}" /></svg>
               HEREDOC
             end
 

--- a/lib/nexmo/oas/renderer/filters/tooltip.rb
+++ b/lib/nexmo/oas/renderer/filters/tooltip.rb
@@ -8,7 +8,7 @@ module Nexmo
               tooltip = <<~HEREDOC
                 <span class="Vlt-tooltip Vlt-tooltip--top" title="#{$2}" tabindex="0">
                   #{$1}&nbsp;
-                  <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-blue" aria-hidden="true"><use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-help-negative"/></svg>
+                  <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-blue" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-help-negative"/></svg>
                 </span>
               HEREDOC
 

--- a/lib/nexmo/oas/renderer/views/open_api/_navigation.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_navigation.erb
@@ -22,7 +22,7 @@
         <% endpoints.each do |endpoint| %>
           <li>
             <a href="#<%= endpoint.operationId %>" class="Vlt-sidemenu__link">
-              <svg class="Vlt-green"><use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-code" /></svg>
+              <svg class="Vlt-green"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-code" /></svg>
 
               <span class="Vlt-sidemenu__label">
                 <%= normalize_summary_title(endpoint.summary, endpoint.operationId) %>
@@ -37,7 +37,7 @@
                 <% path.endpoints.each do |endpoint| %>
                   <li class="Nxd-menu__indent">
                     <a href="#<%= endpoint.operationId %>" class="Vlt-sidemenu__link">
-                      <svg class="Vlt-blue"><use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-toggle" /></svg>
+                      <svg class="Vlt-blue"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-toggle" /></svg>
                       <span class="Vlt-sidemenu__label"><%= endpoint.summary %></span>
                     </a>
                   </li>
@@ -55,7 +55,7 @@
               <% path.endpoints.each do |endpoint| %>
                 <li>
                   <a href="#<%= name %>" class="Vlt-sidemenu__link">
-                    <svg class="Vlt-orange"><use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-mind-map" /></svg>
+                    <svg class="Vlt-orange"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-mind-map" /></svg>
                     <span class="Vlt-sidemenu__label"><%= endpoint.summary %></span>
                   </a>
                 </li>

--- a/lib/nexmo/oas/renderer/views/open_api/show.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/show.erb
@@ -22,14 +22,14 @@
           <div class="Vlt-grid">
             <div class="Vlt-col">
               <a href=<%= url("#{request.url}.#{definition.format}", params: request.params) %> class='Vlt-btn Vlt-btn--secondary Vlt-btn--app'>
-                <svg><use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-download" /></svg>
+                <svg><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-download" /></svg>
                 Download OpenAPI 3 Definition
               </a>
             </div>
             <div class="Vlt-col Vlt-right">
               <a href="https://github.com/Nexmo/api-specification/blob/master/definitions/<%= @specification.definition_name %>.yml" class='Vlt-btn Vlt-btn--tertiary Vlt-btn--app Vlt-right'>
                 <svg className="Vlt-icon Vlt-black">
-                  <use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-github" />
+                  <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-github" />
                 </svg>
                 Improve this specification
               </a>


### PR DESCRIPTION
Found this one by looking into `bugsnag`.

They are under `/symbols` and not `/assets/symbols`