### PR TITLE
Change tag title from H1 to H2 for SEO

### DIFF
--- a/lib/nexmo/oas/renderer/views/open_api/_model.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_model.erb
@@ -1,7 +1,7 @@
 <div class="Vlt-grid <% if !group['schema'] %> Nxd-api--noborder Vlt-article--reverse<% end %>">
   <div class="Vlt-col Vlt-col--2of3 Nxd-api__docs">
     <div>
-      <h1 id="<%= group['name'].parameterize %>" class='Vlt-grey-dark'><%= group['name'] %></h1>
+      <h2 id="<%= group['name'].parameterize %>" class='Vlt-grey-dark'><%= group['name'] %></h2>
       <p class: "Vlt-grey-darker"><%= group['description'] %></p>
 
       <% if group['schema'] %>


### PR DESCRIPTION
Currently, the `tags` in the OAS are being rendered as H1's, in the same way as the API name. For example, see: https://developer.nexmo.com/api/conversation

For SEO purposes, we ideally want all pages to have an H2 header and the tag seems like a great candidate as all subheadings of the tag are H3 or smaller.