### PR TITLE
Fix code_language tabs in NDP.

### DIFF
--- a/lib/nexmo/oas/renderer/app.rb
+++ b/lib/nexmo/oas/renderer/app.rb
@@ -81,6 +81,15 @@ module Nexmo
           end
         end
 
+        def set_code_language
+          return if params[:code_language] == 'templates'
+          @code_language = params[:code_language]
+        end
+
+        before do
+          set_code_language
+        end
+
         get '(/api)/*definition' do
           check_redirect!
 
@@ -104,8 +113,23 @@ module Nexmo
           end
         end
 
-        get '(/api)/*document' do
-          @specification = Presenters::ApiSpecification.new(document_name: params[:document])
+        def set_document
+          if params[:code_language] == 'templates'
+            @document = 'verify/templates'
+          elsif params[:code_language] == 'ncco'
+            @document = 'voice/ncco'
+          else
+            @document = params[:document]
+          end
+        end
+
+        get '(/api)/*document(/:code_language)' do
+          set_document
+
+          @specification = Presenters::ApiSpecification.new(
+            document_name: @document,
+            code_language: @code_language
+          )
 
           @navigation = Presenters::Navigation.new(
             content: @specification.content,

--- a/lib/nexmo/oas/renderer/helpers/url.rb
+++ b/lib/nexmo/oas/renderer/helpers/url.rb
@@ -8,7 +8,7 @@ module Nexmo
           end
 
           def canonical_path
-            request.path.chomp("/#{params[:code_language]}")
+            request.path.chomp("/#{@code_language}")
           end
         end
       end

--- a/lib/nexmo/oas/renderer/presenters/api_specification.rb
+++ b/lib/nexmo/oas/renderer/presenters/api_specification.rb
@@ -4,8 +4,9 @@ module Nexmo
       module Presenters
         class ApiSpecification
 
-          def initialize(document_name:)
+          def initialize(document_name:, code_language: nil)
             @document_name = document_name
+            @code_language = code_language
           end
 
           def side_navigation
@@ -33,7 +34,9 @@ module Nexmo
           end
 
           def content
-            @content ||= MarkdownPipeline.new.call(document)
+            options = {}
+            options.merge(code_language: @code_language) if @code_language
+            @content ||= MarkdownPipeline.new(options).call(document)
           end
         end
       end


### PR DESCRIPTION
When a language was selected, the url was wrongly being updated because
the canonical_path was wrong. This fixes the canonical_path generation
using the right code_language.