### PR TITLE
Debugging + Rendering enhancements

### DIFF
--- a/lib/nexmo/oas/renderer/presenters/response_tab/link.rb
+++ b/lib/nexmo/oas/renderer/presenters/response_tab/link.rb
@@ -12,9 +12,14 @@ module Nexmo
             end
 
             def css_classes
-              classes = ['Vlt-tabs__link']
+              classes = ['tab-sync Vlt-tabs__link']
               classes << 'Vlt-tabs__link_active' if @index.zero?
               classes.join(' ')
+            end
+
+            def data_tab_link
+              return nil unless @schema['x-tab-id']
+              @schema['x-tab-id']
             end
 
             def content

--- a/lib/nexmo/oas/renderer/public/assets/javascripts/nexmo-oas-renderer.js
+++ b/lib/nexmo/oas/renderer/public/assets/javascripts/nexmo-oas-renderer.js
@@ -16,4 +16,16 @@ document.addEventListener("DOMContentLoaded", function() {
     });
   });
 
+  // Handle people clicking on oneOf tabs by changing every one on the page
+  var oneOfTabs = document.querySelectorAll('[data-tab-link]');
+    Array.from(oneOfTabs).forEach(function(element) {
+        element.addEventListener('click', function (event) {
+          var link = event.target.getAttribute('data-tab-link');
+          var matchingTabs = document.querySelectorAll('[data-tab-link="'+link+'"]');
+            Array.from(matchingTabs).forEach(function(element) {
+              element.click();
+            });
+        });
+    });
+
 });

--- a/lib/nexmo/oas/renderer/views/open_api/_endpoint.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_endpoint.erb
@@ -10,6 +10,7 @@
         <code class="Vlt-badge Vlt-badge--large Nxd-method-badge Nxd-method-badge--<%= endpoint.method %>"><%= endpoint.method.upcase %></code>
         <code class="Vlt-badge Vlt-badge--large Vlt-badge--grey">
           <% servers = endpoint.path.servers ? endpoint.path.servers : endpoint.definition.servers %>
+          <% raise "`servers` parameter not provided at either the path level or document root" unless servers.size.positive? %>
           <span><%= servers[0]['url'] %></span><%= endpoint.path.path.gsub(/\{(.+?)\}/, '<span class="api-path-parameter">:\1</span>') %>
         </code>
       </div>

--- a/lib/nexmo/oas/renderer/views/open_api/_navigation.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_navigation.erb
@@ -20,6 +20,7 @@
         <% end %>
 
         <% endpoints.each do |endpoint| %>
+          <% raise "Missing `operationId` on #{endpoint.path.path} path" unless endpoint.operationId %>
           <li>
             <a href="#<%= endpoint.operationId %>" class="Vlt-sidemenu__link">
               <svg class="Vlt-green"><use xlink:href="/assets/symbol/volta-icons.svg#Vlt-icon-code" /></svg>

--- a/lib/nexmo/oas/renderer/views/open_api/_parameters.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_parameters.erb
@@ -137,11 +137,16 @@
             </td>
           <% end %>
 
-          <% if parameter.collection? %>
+          <%
+            should_render_row = false
+            should_render_row = should_render_row || parameter.subproperties_are_one_of_many?
+            should_render_row = should_render_row || (parameter.properties && parameter.object? && parameter.properties.size.positive?)
+          %>
+          <% if parameter.collection? && should_render_row %>
+
             <tr class="Vlt-table__row--nohighlight">
               <td colspan="4">
                 <% if parameter.subproperties_are_one_of_many? %>
-
                   <div style="margin-left: 20px;">
                     <h4>Any one of the following:</h4>
                     <% parameter.properties.each do |property| %>
@@ -150,7 +155,7 @@
                     <% end %>
                   </div>
                 <% else %>
-                  <% if parameter.properties && parameter.object? %>
+                  <% if parameter.properties && parameter.object? && parameter.properties.size.positive? %>
                     <%= erb :'open_api/_parameters', locals: { parameters: parameter.properties, model: model, format: format, callback: callback } %>
                   <% end %>
                 <% end %>

--- a/lib/nexmo/oas/renderer/views/open_api/_response_description_parameters.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_response_description_parameters.erb
@@ -90,7 +90,12 @@
                 <div class="Vlt-tabs js-format">
                   <div class="Vlt-tabs__header" role="tablist" aria-label="Responses">
                     <% schemas.each_with_index do |schema, index| %>
-                      <div class="Vlt-tabs__link <%= index == 0 ? 'Vlt-tabs__link_active' : '' %>">
+                      <div
+                        class="Vlt-tabs__link <%= index == 0 ? 'Vlt-tabs__link_active' : '' %> <%= schema['x-tab-id'] ? "tab-sync" : '' %>"
+                        <% if schema['x-tab-id'] %>
+                          data-tab-link="<%= schema['x-tab-id'] %>"
+                          <% end %>
+                      >
                         <%= schema['description'] %>
                       </div>
                     <% end %>

--- a/lib/nexmo/oas/renderer/views/open_api/_response_description_parameters.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_response_description_parameters.erb
@@ -51,8 +51,8 @@
                 qualifier = 'one'
                 key = 'oneOf'
               else
-                  qualifier = 'any'
-                  key = 'anyOf'
+                qualifier = 'any'
+                key = 'anyOf'
               end
 
               schemas = value['items'][key].map do |item|
@@ -68,55 +68,58 @@
             <% schemas = [value] %>
           <% end %>
 
-          <% if schemas %>
-            <% needs_tabs = schemas.size > 1 %>
-            </td>
-            </tr>
+        <% else %>
+          <% schemas = [value] if value['properties'] %>
+        <% end %>
 
-            <tr class="Vlt-table__row--nohighlight">
-              <td colspan="2">
+        <% if schemas %>
+          <% needs_tabs = schemas.size > 1 %>
+          </td>
+          </tr>
 
-                <% if needs_tabs %>
-                  <div class="Vlt-callout Vlt-callout--shoutout">
-                    <i></i>
-                    <div class="Vlt-callout__content">
-                      This array contains <strong><%= qualifier %></strong> of the following objects:
-                    </div>
+          <tr class="Vlt-table__row--nohighlight">
+            <td colspan="2">
+
+              <% if needs_tabs %>
+                <div class="Vlt-callout Vlt-callout--shoutout">
+                  <i></i>
+                  <div class="Vlt-callout__content">
+                    This array contains <strong><%= qualifier %></strong> of the following objects:
                   </div>
-                  <div class="Vlt-tabs js-format">
-                    <div class="Vlt-tabs__header" role="tablist" aria-label="Responses">
-                      <% schemas.each_with_index do |schema, index| %>
-                        <div class="Vlt-tabs__link <%= index == 0 ? 'Vlt-tabs__link_active' : '' %>">
-                          <%= schema['description'] %>
-                        </div>
-                      <% end %>
-                    </div>
-                    <div class="Vlt-tabs__content">
-                <% end %>
-
-                  <% schemas.each_with_index do |value, index| %>
-                    <div class="Vlt-tabs__panel <%= index == 0 ? 'Vlt-tabs__panel_active' : '' %>">
-                      <div class="Vlt-table Vlt-table--data Vlt-table--bordered">
-                        <table>
-                          <thead>
-                          <tr>
-                            <th>Field</th>
-                            <th>Description</th>
-                          </tr>
-                          </thead>
-                          <tbody>
-                          <%= erb :'open_api/_response_description_parameters', locals: { endpoint: endpoint, schema: value, parent: responseFieldId } %>
-                          </tbody>
-                        </table>
+                </div>
+                <div class="Vlt-tabs js-format">
+                  <div class="Vlt-tabs__header" role="tablist" aria-label="Responses">
+                    <% schemas.each_with_index do |schema, index| %>
+                      <div class="Vlt-tabs__link <%= index == 0 ? 'Vlt-tabs__link_active' : '' %>">
+                        <%= schema['description'] %>
                       </div>
-                    </div>
-                  <% end %>
+                    <% end %>
+                  </div>
+                  <div class="Vlt-tabs__content">
+              <% end %>
 
-                <% if needs_tabs %>
+              <% schemas.each_with_index do |value, index| %>
+                <div class="Vlt-tabs__panel <%= index == 0 ? 'Vlt-tabs__panel_active' : '' %>">
+                  <div class="Vlt-table Vlt-table--data Vlt-table--bordered">
+                    <table>
+                      <thead>
+                      <tr>
+                        <th>Field</th>
+                        <th>Description</th>
+                      </tr>
+                      </thead>
+                      <tbody>
+                      <%= erb :'open_api/_response_description_parameters', locals: { endpoint: endpoint, schema: value, parent: responseFieldId } %>
+                      </tbody>
+                    </table>
                   </div>
-                  </div>
-                <% end %>
-          <% end %>
+                </div>
+              <% end %>
+
+              <% if needs_tabs %>
+                </div>
+                </div>
+              <% end %>
         <% end %>
         </td>
         </tr>

--- a/lib/nexmo/oas/renderer/views/open_api/_response_description_parameters.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_response_description_parameters.erb
@@ -42,9 +42,6 @@
         <% end %>
 
 
-
-
-
         <% if value['items'] # If this is an array, we need to show the structure of the children %>
 
           <% if value['items']['oneOf'] || value['items']['anyOf'] # If it's a oneOf/anyOf, we need tabs! %>

--- a/lib/nexmo/oas/renderer/views/open_api/_response_tabs.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_response_tabs.erb
@@ -3,7 +3,7 @@
 <div class='Vlt-tabs js-format' data-format='<%= tabs.format %>'>
   <div class='Vlt-tabs__header' role='tablist' aria-label='Responses'>
     <% tabs.tab_links.each do |link| %>
-      <div class='<%= link.css_classes %>'>
+      <div class='<%= link.css_classes %>' <% if link.data_tab_link %>data-tab-link="<%= link.data_tab_link %>"<% end %>>
         <%= link.content %>
       </div>
     <% end %>

--- a/spec/lib/nexmo/oas/renderer/presenters/response_tab/link_spec.rb
+++ b/spec/lib/nexmo/oas/renderer/presenters/response_tab/link_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Nexmo::OAS::Renderer::Presenters::ResponseTab::Link do
       let(:index) { 0 }
 
       it 'includes the active class' do
-        expect(subject.css_classes).to eq('Vlt-tabs__link Vlt-tabs__link_active')
+        expect(subject.css_classes).to eq('tab-sync Vlt-tabs__link Vlt-tabs__link_active')
       end
     end
 
@@ -18,7 +18,7 @@ RSpec.describe Nexmo::OAS::Renderer::Presenters::ResponseTab::Link do
       let(:index) { 1 }
 
       it 'returns the basic class' do
-        expect(subject.css_classes).to eq('Vlt-tabs__link')
+        expect(subject.css_classes).to eq('tab-sync Vlt-tabs__link')
       end
     end
   end


### PR DESCRIPTION
This started out as additional debugging for invalid OAS docs, but has resulted in bug fixes for the `oneOf` rendering discovered when working with the conversation API OAS.

It also introduces a new feature, which allows us to sync the state of shown `oneOf` tabs using `x-tab-link`