### PR TITLE
Fix api/sms links.

### DIFF
--- a/lib/nexmo/oas/renderer/app.rb
+++ b/lib/nexmo/oas/renderer/app.rb
@@ -118,8 +118,10 @@ module Nexmo
             @document = 'verify/templates'
           elsif params[:code_language] == 'ncco'
             @document = 'voice/ncco'
-          else
+          elsif CodeLanguage.exists?(params[:code_language])
             @document = params[:document]
+          else
+            @document = "#{params[:document]}/#{params[:code_language]}"
           end
         end
 


### PR DESCRIPTION
The url was being parsed incorrectly (the doc's name was being
interpreted as the code_language). This checks if the code_language is
valid and acts accordingly.