### PR TITLE
Add x-tab-id support to request bodies

### DIFF
--- a/lib/nexmo/oas/renderer/public/assets/javascripts/nexmo-oas-renderer.js
+++ b/lib/nexmo/oas/renderer/public/assets/javascripts/nexmo-oas-renderer.js
@@ -23,7 +23,7 @@ document.addEventListener("DOMContentLoaded", function() {
           var link = event.target.getAttribute('data-tab-link');
           var matchingTabs = document.querySelectorAll('[data-tab-link="'+link+'"]');
             Array.from(matchingTabs).forEach(function(element) {
-              element.click();
+              element.dispatchEvent(new Event('toggle'));
             });
         });
     });

--- a/lib/nexmo/oas/renderer/public/assets/javascripts/volta.tabs.js
+++ b/lib/nexmo/oas/renderer/public/assets/javascripts/volta.tabs.js
@@ -48,6 +48,10 @@ Volta.tab = function () {
         _this._links.forEach(function(link){
           var link = link;
 
+          link.addEventListener('toggle', function() {
+              _this.toggle(link);
+          });
+
           link.addEventListener('click', function() {
             _this.toggle(link);
           });

--- a/lib/nexmo/oas/renderer/views/open_api/_parameter_groups.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_parameter_groups.erb
@@ -63,6 +63,7 @@
         panels.push({
           'description' => description,
           'parameters' => parameters,
+          'x-tab-id' => c['x-tab-id'],
           'active' => index == 0
         })
       end
@@ -71,7 +72,7 @@
     <div class="Vlt-tabs js-format" data-format="<%= format %>">
       <div class="Vlt-tabs__header" role="tablist" aria-label="Responses">
         <% panels.each do |panel| %>
-        <div class="Vlt-tabs__link <%= panel['active'] ? 'Vlt-tabs__link_active' : '' %>">
+        <div data-tab-link="<%= panel['x-tab-id'] %>" class="Vlt-tabs__link <%= panel['active'] ? 'Vlt-tabs__link_active' : '' %>">
           <%= panel['description'] %>
         </div>
         <% end %>


### PR DESCRIPTION
Make all the oneOf tabs sync on request bodies in addition to response descriptions and examples

This includes a hack in Volta tabs to add a `toggle` event to prevent `.click()` recursion.