### PR TITLE
Remove the need to have a `_definitions` folder.

### DIFF
--- a/lib/nexmo/oas/renderer/app.rb
+++ b/lib/nexmo/oas/renderer/app.rb
@@ -73,7 +73,7 @@ module Nexmo
 
         unless defined?(NexmoDeveloper::Application)
           get '/' do
-            prefix = "#{API.oas_path}/definitions"
+            prefix = "#{API.oas_path}"
             @definitions = Dir.glob("#{prefix}/**/*.yml").map do |d|
               d.gsub("#{prefix}/", '').gsub('.yml', '')
             end.sort.reject { |d| d.include? 'common/' }

--- a/lib/nexmo/oas/renderer/presenters/open_api_specification.rb
+++ b/lib/nexmo/oas/renderer/presenters/open_api_specification.rb
@@ -26,12 +26,12 @@ module Nexmo
           end
 
           def errors?
-            File.exist?("#{API.oas_path}/../errors/#{@definition_name}.md")
+            File.exist?("#{API.oas_path}/../../errors/#{@definition_name}.md")
           end
 
           def definition_errors
             @definition_errors ||= MarkdownPipeline.new.call(
-              File.read("#{API.oas_path}/../errors/#{@definition_name}.md")
+              File.read("#{API.oas_path}/../../errors/#{@definition_name}.md")
             ) if errors?
           end
 

--- a/lib/nexmo/oas/renderer/services/open_api_definition_resolver.rb
+++ b/lib/nexmo/oas/renderer/services/open_api_definition_resolver.rb
@@ -21,7 +21,7 @@ module Nexmo
         end
 
         def self.path(name, format)
-          "#{API.oas_path}/definitions/#{name}.#{format}"
+          "#{API.oas_path}/#{name}.#{format}"
         end
 
         def self.resolve(path)


### PR DESCRIPTION
 Makes the renderer less dependant of NDP.

We can include it as part of the OAS_PATH.