### PR TITLE
Prevent sinatra from showing error traces.

### DIFF
--- a/lib/nexmo/oas/renderer/app.rb
+++ b/lib/nexmo/oas/renderer/app.rb
@@ -33,7 +33,6 @@ module Nexmo
         end
 
         set :mustermann_opts, { type: :rails }
-        set :show_exceptions, :after_handler
         set :oas_path, (ENV['OAS_PATH'] || '.')
 
         helpers do
@@ -69,6 +68,10 @@ module Nexmo
         error Errno::ENOENT do
           layout = defined?(NexmoDeveloper::Application) ? :'layouts/api.html' : false
           not_found erb :'static/404', layout: layout
+        end
+
+        error Exception do
+          File.read("#{API.root}/public/500.html")
         end
 
         unless defined?(NexmoDeveloper::Application)

--- a/lib/nexmo/oas/renderer/public/500.html
+++ b/lib/nexmo/oas/renderer/public/500.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>We're sorry, but something went wrong (500)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/500.html -->
+  <div class="dialog">
+    <div>
+      <h1>We're sorry, but something went wrong.</h1>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
+  </div>
+</body>
+</html>

--- a/lib/nexmo/oas/renderer/services/open_api_definition_resolver.rb
+++ b/lib/nexmo/oas/renderer/services/open_api_definition_resolver.rb
@@ -11,7 +11,7 @@ module Nexmo
 
           return resolve(path) if path
 
-          raise "Could not find definition '#{name}' in '#{API.oas_path}'"
+          raise Errno::ENOENT, "Could not find definition '#{name}' in '#{API.oas_path}'"
         end
 
         def self.paths(name)


### PR DESCRIPTION
* Use default settings for error handling (`show_exceptions`): Shows a stack
trace in the browser when an exception happens. Enabled by default when
environment is set to "development", disabled otherwise.

* Raise appropriate exception when a doc is not found.

* Use custom 500 page for errors.