### PR TITLE
Fix version rendering after changing the path.

### DIFF
--- a/lib/nexmo/oas/renderer/presenters/versions.rb
+++ b/lib/nexmo/oas/renderer/presenters/versions.rb
@@ -37,8 +37,8 @@ module Nexmo
 
           def definitions
             @definitions ||= begin
-                               Dir.glob("#{API.oas_path}/definitions/**/*.yml").map do |file|
-                                 definition = file.sub("#{API.oas_path}/definitions/", '').chomp('.yml')
+                               Dir.glob("#{API.oas_path}/**/*.yml").map do |file|
+                                 definition = file.sub("#{API.oas_path}/", '').chomp('.yml')
                                end
                              end
           end


### PR DESCRIPTION
Looks like we merged [this](https://github.com/Nexmo/nexmo-oas-renderer/pull/35/) after adding `definitions` from the path.