### PR TITLE
When there is no description at the parameter level, the one in the

### DIFF
--- a/lib/nexmo/oas/renderer/views/open_api/_parameters.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_parameters.erb
@@ -75,10 +75,10 @@
           <td>
             <% if parameter.collection? || parameter.oneOf? %>
               <% if parameter.raw['x-nexmo-developer-collection-description-shown'] %>
-                <%= (parameter.description ? "#{parameter.description}" : '<i>None</i>').render_markdown %>
+                <%= (parameter.description || parameter.schema['description'] || '<i>None</i>').render_markdown %>
               <% end %>
             <% else %>
-              <%= (parameter.description ? "#{parameter.description}" : '<i>None</i>').render_markdown %>
+              <%= (parameter.description || parameter.schema['description'] || '<i>None</i>').render_markdown %>
             <% end %>
 
             <% if parameter.enum %>


### PR DESCRIPTION
schema is used.

Fixes #44 