### PR TITLE
Render endpoint's description as markdown.

### DIFF
--- a/lib/nexmo/oas/renderer/views/open_api/_model.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_model.erb
@@ -2,7 +2,7 @@
   <div class="Vlt-col Vlt-col--2of3 Nxd-api__docs">
     <div>
       <h2 id="<%= group['name'].parameterize %>" class='Vlt-grey-dark'><%= group['name'] %></h2>
-      <p class: "Vlt-grey-darker"><%= group['description'] %></p>
+      <p class: "Vlt-grey-darker"><%= group['description'].render_markdown %></p>
 
       <% if group['schema'] %>
         <% group['schema'].each do |format, schema| %>


### PR DESCRIPTION
Currently, the description is being rendered as a plain string.

<img width="729" alt="Screenshot 2020-01-28 at 13 16 42" src="https://user-images.githubusercontent.com/715229/73263250-7202a380-41d0-11ea-9009-2f53667ef9d9.png">


With the new change,

<img width="799" alt="Screenshot 2020-01-28 at 13 17 12" src="https://user-images.githubusercontent.com/715229/73263278-85ae0a00-41d0-11ea-8f00-3ba8c5857884.png">
