### PR TITLE
Always render a collection's description and example.

### DIFF
--- a/lib/nexmo/oas/renderer/views/open_api/_parameters.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_parameters.erb
@@ -73,12 +73,10 @@
           else
         %>
           <td>
-            <% if parameter.collection? || parameter.oneOf? %>
-              <% if parameter.raw['x-nexmo-developer-collection-description-shown'] %>
-                <%= (parameter.description || parameter.schema['description'] || '<i>None</i>').render_markdown %>
-              <% end %>
-            <% else %>
+            <% if parameter.raw['x-nexmo-developer-collection-description-shown'] %>
               <%= (parameter.description || parameter.schema['description'] || '<i>None</i>').render_markdown %>
+            <% else %>
+              <%= (parameter.description || parameter.schema['description'])&.render_markdown %>
             <% end %>
 
             <% if parameter.enum %>
@@ -113,11 +111,9 @@
 
           <% unless model %>
             <% if parameter.collection? || parameter.oneOf? %>
-              <% if parameter.raw['x-nexmo-developer-collection-description-shown'] %>
-                <td>
-                  <%= (parameter.example ? "<code><pre>#{parameter.example}</pre></code>" : '')%>
-                </td>
-              <% end %>
+              <td>
+                <%= (parameter.example ? "<code><pre>#{parameter.example}</pre></code>" : '')%>
+              </td>
             <% else %>
               <td>
                 <%= (parameter.example ? "<code>#{parameter.example.to_s.gsub("\n", "<br />")}</code>" : '<i>None</i>')%>


### PR DESCRIPTION
This removes the need of the
`x-nexmo-developer-collection-description-shown` property in the api
specifications, and treats collections as any other type.

Doesn't break backward compatibility and renders arrays for all the oas