### PR TITLE
Allow multi-depth oneOf definitions

### DIFF
--- a/lib/nexmo/oas/renderer/views/open_api/_parameter_groups.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_parameter_groups.erb
@@ -49,41 +49,11 @@
 
     <%
       # This can likely be better done as a presenter, but it works for now
-      panels = []
-      endpoint.request_body.split_properties_for_format(format).each_with_index do |parameters, index|
-        description = 'Request body'
-        c = parameters[0].schema
-        description = c['description'] if c['description']
-        if c['allOf']
-          c['allOf'].each_with_index do |current, index|
-            description = c[index]['description'] if c[index]['description']
-          end
-        end
+      schema = endpoint.request_body.content[format]['schema']['oneOf']
+      %>
+      <%= erb :'open_api/_tabbed_parameters', locals: { body: endpoint.request_body, schema: schema, format: format, callback: callback } %>
+    <%
+    end
+  end
+%>
 
-        panels.push({
-          'description' => description,
-          'parameters' => parameters,
-          'x-tab-id' => c['x-tab-id'],
-          'active' => index == 0
-        })
-      end
-    %>
-
-    <div class="Vlt-tabs js-format" data-format="<%= format %>">
-      <div class="Vlt-tabs__header" role="tablist" aria-label="Responses">
-        <% panels.each do |panel| %>
-        <div data-tab-link="<%= panel['x-tab-id'] %>" class="Vlt-tabs__link <%= panel['active'] ? 'Vlt-tabs__link_active' : '' %>">
-          <%= panel['description'] %>
-        </div>
-        <% end %>
-      </div>
-      <div class="Vlt-tabs__content">
-        <% panels.each do |panel| %>
-          <div class="Vlt-tabs__panel <%= panel['active'] ? 'Vlt-tabs__panel_active' : '' %>">
-            <%= erb :'open_api/_parameters', locals: { parameters: panel['parameters'], callback: callback } %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
-<% end %>

--- a/lib/nexmo/oas/renderer/views/open_api/_tabbed_parameters.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_tabbed_parameters.erb
@@ -1,0 +1,53 @@
+<%
+  # Handle any cases where the top level of the oneOf is an allOf
+  schemas = schema.map { |s| body.handle_all_of(s) }
+
+  panels = []
+
+  schemas.each_with_index do |schema, index|
+    if schema['properties']
+      schema['properties'] = schema['properties'].map do |name, definition|
+        OasParser::Property.new(self, schema, name, definition)
+      end
+      .sort_by do |prop|
+        prop.required ? -1 : 1
+      end
+    end
+
+    panels.push({
+      'description' => schema['title'] || schema['description'],
+      'parameters' => schema['properties'],
+      'oneOf' => schema['oneOf'],
+      'x-tab-id' => schema['x-tab-id'],
+      'active' => index == 0
+    })
+  end
+%>
+
+<div class="Vlt-tabs js-format" data-format="<%= format %>">
+  <div class="Vlt-tabs__header" role="tablist" aria-label="Responses">
+    <% panels.each do |panel| %>
+      <div data-tab-link="<%= panel['x-tab-id'] %>" class="Vlt-tabs__link <%= panel['active'] ? 'Vlt-tabs__link_active' : '' %>">
+        <%= panel['description'] %>
+      </div>
+    <% end %>
+  </div>
+  <div class="Vlt-tabs__content">
+    <% panels.each do |panel| %>
+      <div class="Vlt-tabs__panel <%= panel['active'] ? 'Vlt-tabs__panel_active' : '' %>">
+      <%
+        # Nested oneOf?
+        if panel['oneOf']
+          %>
+          <%= erb :'open_api/_tabbed_parameters', locals: { body: body, schema: panel['oneOf'], format: format, callback: callback } %>
+        <%
+        else
+        %>
+
+        <%= erb :'open_api/_parameters', locals: { parameters: panel['parameters'], callback: callback } %>
+      <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+


### PR DESCRIPTION
This PR adds support for multi-level `oneOf` rendering. It's not currently used anywhere (other than a WIP definition that I'm working on) so here's a screenshot:

![image](https://user-images.githubusercontent.com/59130/74610198-e0a89200-50e8-11ea-8df5-88ef8bc8f5c3.png)
