### PR TITLE
Remove white box on HTTP responses

### DIFF
--- a/lib/nexmo/oas/renderer/public/assets/stylesheets/nexmo-oas-renderer.css
+++ b/lib/nexmo/oas/renderer/public/assets/stylesheets/nexmo-oas-renderer.css
@@ -88,7 +88,7 @@ body {
     top: 30px;
     position: sticky;
     display: block;
-    overflow: scroll; }
+    overflow: auto; }
   .Nxd-api__code {
     background: #e7ebee;
     border-bottom: 1px solid #f8fafc;


### PR DESCRIPTION
Swaps from `overflow: scroll` to `overflow: auto` to prevent the white, empty scrollbars showing up all the time.

From this:

![image](https://user-images.githubusercontent.com/59130/74731216-7b1ae980-523f-11ea-9ae3-c07e03795124.png)

To this:

![image](https://user-images.githubusercontent.com/59130/74731264-8b32c900-523f-11ea-92b7-b926fe2e3cb2.png)
