### PR TITLE
update markdown renderer versioning

### DIFF
--- a/lib/nexmo/oas/renderer/version.rb
+++ b/lib/nexmo/oas/renderer/version.rb
@@ -1,7 +1,7 @@
 module Nexmo
   module OAS
     module Renderer
-      VERSION = "0.7.1"
+      VERSION = "0.7.2"
     end
   end
 end

--- a/nexmo-oas-renderer.gemspec
+++ b/nexmo-oas-renderer.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'sass', '~> 3.1'
   spec.add_runtime_dependency 'activemodel', '~> 6.0'
   spec.add_runtime_dependency "dotenv", "~> 2.7"
-  spec.add_runtime_dependency 'nexmo_markdown_renderer', '>= 0.0.2'
+  spec.add_runtime_dependency 'nexmo_markdown_renderer', '>= 0.0.3'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Update `nexmo_markdown_renderer` to v0.0.3