### PR TITLE
Address Bug With Docs in Non-OAS Folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.8.1
+* Fix an issue where API docs were not being found
+
 # 0.8.0
 * Fix an issue when the description is `nil`
 * Include nexmo-markdown-renderer

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ $ cp .env.example .env
 and assign values to the corresponding variables.
 
 #### Note
-The env variable `OAS_PATH` indicates the path to the documents that will be rendered.
+The env variable `OAS_PATH` indicates the path to the OpenAPI documents that will be rendered.
+The env variable `API_PATH` indicates the path to other API documents that will be rendered.
 
 ## Contributing
 We ❤️ contributions from everyone! [Bug reports](https://github.com/Nexmo/nexmo-oas-renderer/issues), [bug fixes](https://github.com/Nexmo/nexmo-oas-renderer/pulls) and feedback on the library is always appreciated. Look at the [Contributor Guidelines](https://github.com/Nexmo/nexmo-oas-renderer/blob/master/CONTRIBUTING.md) for more information and please follow the [GitHub Flow](https://guides.github.com/introduction/flow/index.html).

--- a/lib/nexmo/oas/renderer/app.rb
+++ b/lib/nexmo/oas/renderer/app.rb
@@ -31,6 +31,7 @@ module Nexmo
 
         set :mustermann_opts, { type: :rails }
         set :oas_path, (ENV['OAS_PATH'] || './')
+        set :api_path, (ENV['API_PATH'] || './')
         set :bind, '0.0.0.0'
 
         helpers do

--- a/lib/nexmo/oas/renderer/presenters/api_specification.rb
+++ b/lib/nexmo/oas/renderer/presenters/api_specification.rb
@@ -14,7 +14,7 @@ module Nexmo
           end
 
           def document_path
-            "_api/#{@document_name}.md"
+            "#{API.api_path}/#{@document_name}.md"
           end
 
           def document

--- a/lib/nexmo/oas/renderer/version.rb
+++ b/lib/nexmo/oas/renderer/version.rb
@@ -1,7 +1,7 @@
 module Nexmo
   module OAS
     module Renderer
-      VERSION = "0.8.0"
+      VERSION = "0.8.1"
     end
   end
 end


### PR DESCRIPTION
There are times where some API docs one wishes to render are not in the OAS path, but they were not being rendered as they could not be found. This fixes that bug by adding a `api_path` and using it for the location of those docs.