### PR TITLE
Remove trailing slash from endpoints

### DIFF
--- a/lib/nexmo/oas/renderer/views/open_api/_endpoint.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_endpoint.erb
@@ -10,7 +10,7 @@
     <% raise "`servers` parameter not provided at either the path level or document root" unless servers.size.positive? %>
 
     <%
-      path = endpoint.path.path.gsub(/\{(.+?)\}/, ':\1')
+      path = endpoint.path.path.gsub(/\{(.+?)\}/, ':\1').chomp("/")
       uri = URI("#{servers[0]['url']}#{path}")
     %>
     <div class="oas-path-full Vlt-badge-combined">


### PR DESCRIPTION
Some of our endpoints don't work with a trailing slash e.g. `/v0.1/messages/`

There are engineering tickets open to fix this, but for now we can fix it in our renderer