### PR TITLE
Check for oas-wrapper existence once the DOM has loaded

### DIFF
--- a/lib/nexmo/oas/renderer/public/assets/javascripts/nexmo-oas-renderer.js
+++ b/lib/nexmo/oas/renderer/public/assets/javascripts/nexmo-oas-renderer.js
@@ -1,4 +1,9 @@
-if(document.querySelector(".oas-wrapper")){
+document.addEventListener("DOMContentLoaded", function() {
+  // Only run this JS on OAS pages
+  if(!document.querySelector(".oas-wrapper")){
+    return;
+  }
+
   if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
     var queryString = new URLSearchParams(window.location.search);
     if (!queryString.get('theme')) {
@@ -7,59 +12,56 @@ if(document.querySelector(".oas-wrapper")){
     }
   }
 
-  document.addEventListener("DOMContentLoaded", function() {
-    // Handle people clicking on oneOf tabs by changing every one on the page
-    var oneOfTabs = document.querySelectorAll('[data-tab-link]');
-    Array.from(oneOfTabs).forEach(function (element) {
-      element.addEventListener('click', function (event) {
-        var link = event.target.getAttribute('data-tab-link');
-        var matchingTabs = document.querySelectorAll('[data-tab-link="' + link + '"]');
-        Array.from(matchingTabs).forEach(function (element) {
-          element.dispatchEvent(new Event('toggle'));
-        });
+  // Handle people clicking on oneOf tabs by changing every one on the page
+  var oneOfTabs = document.querySelectorAll('[data-tab-link]');
+  Array.from(oneOfTabs).forEach(function (element) {
+    element.addEventListener('click', function (event) {
+      var link = event.target.getAttribute('data-tab-link');
+      var matchingTabs = document.querySelectorAll('[data-tab-link="' + link + '"]');
+      Array.from(matchingTabs).forEach(function (element) {
+        element.dispatchEvent(new Event('toggle'));
       });
     });
+  });
 
-    var toggleTopNav = function(event, closeOnly) {
+  var toggleTopNav = function(event, closeOnly) {
 
-      if (event) {
-        if (!Array.from(event.target.classList).includes("oas-trigger")) {
-          return;
-        }
-      }
-
-      var c = document.querySelector('.oas-trigger-content');
-      if (closeOnly === true) {
-        c.style.display = "none";
+    if (event) {
+      if (!Array.from(event.target.classList).includes("oas-trigger")) {
         return;
       }
-      c.style.display = c.style.display == 'block' ? 'none' : "block";
-    };
-
-    if (document.querySelector('.oas-trigger')) {
-      document.querySelector('.oas-trigger').addEventListener("click", toggleTopNav);
     }
 
-    document.querySelectorAll('a').forEach((element) => {
-      var href = element.getAttribute("href");
-      if (!href){ return; }
-      if (href.slice(0,1) !== "#"){ return; }
-      element.addEventListener('click', function (event) {
-        event.preventDefault();
+    var c = document.querySelector('.oas-trigger-content');
+    if (closeOnly === true) {
+      c.style.display = "none";
+      return;
+    }
+    c.style.display = c.style.display == 'block' ? 'none' : "block";
+  };
 
-        toggleTopNav(null, true);
+  if (document.querySelector('.oas-trigger')) {
+    document.querySelector('.oas-trigger').addEventListener("click", toggleTopNav);
+  }
 
-        var to = document.querySelector(event.target.hash)
-        history.pushState({}, '', event.target.href);
-        window.scrollTo({
-          top: (window.scrollY + to.getBoundingClientRect().y) - 70,
-          left: 0,
-        })
+  document.querySelectorAll('a').forEach((element) => {
+    var href = element.getAttribute("href");
+    if (!href){ return; }
+    if (href.slice(0,1) !== "#"){ return; }
+    element.addEventListener('click', function (event) {
+      event.preventDefault();
+
+      toggleTopNav(null, true);
+
+      var to = document.querySelector(event.target.hash)
+      history.pushState({}, '', event.target.href);
+      window.scrollTo({
+        top: (window.scrollY + to.getBoundingClientRect().y) - 70,
+        left: 0,
+      })
 
 
-      });
     });
-
   });
-}
+});
 


### PR DESCRIPTION
The existing check works on a standalone OAS renderer as the page
initialises quickly. In production there is a race condition where
the check runs before the page is initialised, leading to the JS not
being executed