### PR TITLE
Fix allOf in RequestBody entries

### DIFF
--- a/lib/nexmo/oas/renderer/views/open_api/_parameter_groups.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_parameter_groups.erb
@@ -29,14 +29,7 @@
   <% unless endpoint.request_body.exhibits_one_of_multiple_schemas?(format) %>
 
     <%
-      # @mheap: This is hacky handling for allOf, but it works for now
-      # We probably want real allOf support in OasParser, but that's more time than I have right now
-      allOf = endpoint.request_body.content[format]['schema']['allOf']
-      if allOf
-        params = endpoint.request_body.handle_all_of(allOf)
-      else
-        params = endpoint.request_body.properties_for_format(format)
-      end
+      params = endpoint.request_body.properties_for_format(format)
       if params
     %>
 


### PR DESCRIPTION
We previously handled allOf in request bodies manually as the OAS Parser did not support allOf. The parser has since added support which meant that we could end up trying to call handle_all_of on an array, rather than a hash containing an allOf entry

The solution for this is to remove the hack previously added. It has been tested on all existing specs and they do not throw a 500