### PR TITLE
Adding error list to the bottom of the renderer

### DIFF
--- a/lib/nexmo/oas/renderer/views/open_api/_errors.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_errors.erb
@@ -4,7 +4,7 @@
             <div class="Vlt-col oas-left-panel" style="padding-bottom: 36px;">
                 <h2 id="errors">Errors</h2>
                 <p>
-                    The following are common error codes that can occur while using this API.
+                  The following is a non-exhaustive list of error codes that may occur while using this API. These codes are in addition to any of our <a href="/api-errors">generic error codes</a>.
                 </p>
             </div>
             <div class="Vlt-col oas-right-panel"></div>

--- a/lib/nexmo/oas/renderer/views/open_api/_errors.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_errors.erb
@@ -15,7 +15,7 @@
                     <thead>
                         <tr>
                             <th>Title</th>
-                            <th>Description</th>
+                            <th>Details</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/lib/nexmo/oas/renderer/views/open_api/_errors.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_errors.erb
@@ -1,0 +1,34 @@
+<% if definition.raw['x-errors'] %>
+    <div>
+        <div class="Vlt-grid">
+            <div class="Vlt-col oas-left-panel" style="padding-bottom: 36px;">
+                <h2 id="errors">Errors</h2>
+                <p>
+                    The following are common error codes that can occur while using this API.
+                </p>
+            </div>
+            <div class="Vlt-col oas-right-panel"></div>
+        </div>
+        <div class="Vlt-grid">
+            <div class="Vlt-col Vlt-table Vlt-table--bordered oas-left-panel">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Title</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    <% definition.raw['x-errors'].each do |name, body| %>
+                        <tr>
+                            <td><b><%= name %></b></td>
+                            <td><%= body['description'].render_markdown %> </td>
+                        </tr>
+                    <% end %>
+                    </tbody>
+                </table>
+            </div>
+            <div class="Vlt-col oas-right-panel"></div>
+        </div>
+    </div>
+<% end %>

--- a/lib/nexmo/oas/renderer/views/open_api/_errors.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_errors.erb
@@ -10,18 +10,18 @@
             <div class="Vlt-col oas-right-panel"></div>
         </div>
         <div class="Vlt-grid">
-            <div class="Vlt-col Vlt-table Vlt-table--bordered oas-left-panel">
+            <div class="Vlt-col Vlt-table oas-left-panel">
                 <table>
                     <thead>
                         <tr>
-                            <th>Title</th>
+                            <th>Code</th>
                             <th>Details</th>
                         </tr>
                     </thead>
                     <tbody>
                     <% definition.raw['x-errors'].each do |name, body| %>
                         <tr>
-                            <td><b><%= name %></b></td>
+                          <td><a href="/api-errors/<%= @specification.definition_name %>#<%= name %>"><b><%= name %></b></a></td>
                             <td><%= body['description'].render_markdown %> </td>
                         </tr>
                     <% end %>

--- a/lib/nexmo/oas/renderer/views/open_api/_navigation.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_navigation.erb
@@ -13,6 +13,9 @@
     <a href="#webhooks" class="Vlt-btn Vlt-btn--tertiary group-link">Webhooks</a>
   <% end %>
 
+  <% if definition.raw['x-errors'] %>
+    <a href="#errors" class="Vlt-btn Vlt-btn--tertiary group-link">Errors</a>
+  <% end %>
 
   <% if @specification.formats.size > 1 %>
     <div class="Vlt-native-dropdown">
@@ -42,6 +45,10 @@
     <div class="oas-trigger-content">
       <% if @specification.groups.size == 1 %>
       <a href="#top" class="Vlt-btn Vlt-btn--tertiary group-link">Available Operations</a>
+      <% end %>
+
+      <% if definition.raw['x-errors'] %>
+        <a href="#errors" class="Vlt-btn Vlt-btn--tertiary group-link">Errors</a>
       <% end %>
 
       <br />

--- a/lib/nexmo/oas/renderer/views/open_api/show.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/show.erb
@@ -21,6 +21,6 @@
     <% end %>
 
     <%= erb :'open_api/_webhooks', locals: { definition: definition } %>
-
+    <%= erb :'open_api/_errors', locals: {definition: definition } %>
   </div>
 </div>


### PR DESCRIPTION
Adding error list to the bottom of the renderer, generated from the list of x-error codes at the bottom of the spec.