### PR TITLE
Examples support

### DIFF
--- a/lib/nexmo/oas/renderer/presenters/content_switcher.rb
+++ b/lib/nexmo/oas/renderer/presenters/content_switcher.rb
@@ -5,7 +5,6 @@ module Nexmo
     module Renderer
       module Presenters
         class ContentSwitcher
-
           attr_reader :panels
 
           def initialize(format:, label: nil, theme_light:, force_type: nil)

--- a/lib/nexmo/oas/renderer/presenters/content_switcher.rb
+++ b/lib/nexmo/oas/renderer/presenters/content_switcher.rb
@@ -5,7 +5,10 @@ module Nexmo
     module Renderer
       module Presenters
         class ContentSwitcher
-          def initialize(format:, label:, theme_light:, force_type: nil)
+
+          attr_reader :panels
+
+          def initialize(format:, label: nil, theme_light:, force_type: nil)
             @format = format
             @panels = []
             @label = label

--- a/lib/nexmo/oas/renderer/presenters/response_tab/panel.rb
+++ b/lib/nexmo/oas/renderer/presenters/response_tab/panel.rb
@@ -24,7 +24,6 @@ module Nexmo
             end
 
             def content
-
               if @content.is_a?(Nexmo::OAS::Renderer::Presenters::ContentSwitcher)
                 return @content.render
               end

--- a/lib/nexmo/oas/renderer/presenters/response_tab/panel.rb
+++ b/lib/nexmo/oas/renderer/presenters/response_tab/panel.rb
@@ -24,6 +24,11 @@ module Nexmo
             end
 
             def content
+
+              if @content.is_a?(Nexmo::OAS::Renderer::Presenters::ContentSwitcher)
+                return @content.render
+              end
+
               if @content == :responses
                 Nexmo::OAS::Renderer::ResponseParserDecorator
                   .new(@schema)

--- a/lib/nexmo/oas/renderer/presenters/response_tabs.rb
+++ b/lib/nexmo/oas/renderer/presenters/response_tabs.rb
@@ -32,15 +32,49 @@ module Nexmo
           def tab_panels
             @tab_panels ||= @response.split_schemas(@format).map.with_index do |schema, index|
               schema = handle_all_of(schema)
+              examples = examples_for_schema(schema)
               ResponseTab::Panel.new(
                 schema: schema,
                 index: index,
                 format: @format,
-                content: @content,
+                content: examples || @content,
                 endpoint: @endpoint,
-                theme_light: @theme_light
+                theme_light: @theme_light,
               )
             end
+          end
+
+          def examples_for_schema(schema)
+            # If there are any examples, show them
+            examples = @response.raw['content'][@format]['examples']
+            if @content == :responses && @format == "application/json" && examples
+              example_switcher = Nexmo::OAS::Renderer::Presenters::ContentSwitcher.new(format: format, force_type: 'dropdown', theme_light: @theme_light)
+
+              has_visible_panel = false
+              examples.each_with_index do |v,k|
+                # Only if the example key is listed in x-examples in the schema
+                next unless schema['x-examples']&.include?(v[0])
+
+                response = JSON.neat_generate(v[1], {
+                    wrap: true,
+                    after_colon: 1,
+                })
+
+                content = <<~HEREDOC
+        <pre class="pre-wrap language-json #{@theme_light ? 'Vlt-prism--dark' : ''} Vlt-prism--copy-disabled"><code>#{response}</code></pre>
+                HEREDOC
+
+                example_switcher.add_content(
+                    title: v[0].titleize,
+                    content: content,
+                    tab_id: v[0],
+                    active: !has_visible_panel
+                )
+                has_visible_panel = true
+              end
+              return example_switcher if example_switcher.panels.size.positive?
+            end
+
           end
 
           def handle_all_of(schema)

--- a/lib/nexmo/oas/renderer/presenters/response_tabs.rb
+++ b/lib/nexmo/oas/renderer/presenters/response_tabs.rb
@@ -46,7 +46,7 @@ module Nexmo
 
           def examples_for_schema(schema)
             # If there are any examples, show them
-            examples = @response.raw['content'][@format]['examples']
+            examples = @response.raw.dig('content', @format, 'examples')
             if @content == :responses && @format == "application/json" && examples
               example_switcher = Nexmo::OAS::Renderer::Presenters::ContentSwitcher.new(format: format, force_type: 'dropdown', theme_light: @theme_light)
 

--- a/lib/nexmo/oas/renderer/presenters/response_tabs.rb
+++ b/lib/nexmo/oas/renderer/presenters/response_tabs.rb
@@ -39,7 +39,7 @@ module Nexmo
                 format: @format,
                 content: examples || @content,
                 endpoint: @endpoint,
-                theme_light: @theme_light,
+                theme_light: @theme_light
               )
             end
           end
@@ -47,34 +47,33 @@ module Nexmo
           def examples_for_schema(schema)
             # If there are any examples, show them
             examples = @response.raw.dig('content', @format, 'examples')
-            if @content == :responses && @format == "application/json" && examples
-              example_switcher = Nexmo::OAS::Renderer::Presenters::ContentSwitcher.new(format: format, force_type: 'dropdown', theme_light: @theme_light)
+            return nil unless @content == :responses && @format == 'application/json' && examples
 
-              has_visible_panel = false
-              examples.each_with_index do |v,k|
-                # Only if the example key is listed in x-examples in the schema
-                next unless schema['x-examples']&.include?(v[0])
+            example_switcher = Nexmo::OAS::Renderer::Presenters::ContentSwitcher.new(format: format, force_type: 'dropdown', theme_light: @theme_light)
 
-                response = JSON.neat_generate(v[1], {
-                    wrap: true,
-                    after_colon: 1,
-                })
+            has_visible_panel = false
+            examples.each_with_index do |v, _k|
+              # Only if the example key is listed in x-examples in the schema
+              next unless schema['x-examples']&.include?(v[0])
 
-                content = <<~HEREDOC
-        <pre class="pre-wrap language-json #{@theme_light ? 'Vlt-prism--dark' : ''} Vlt-prism--copy-disabled"><code>#{response}</code></pre>
-                HEREDOC
+              response = JSON.neat_generate(v[1], {
+                  wrap: true,
+                  after_colon: 1,
+              })
 
-                example_switcher.add_content(
-                    title: v[0].titleize,
-                    content: content,
-                    tab_id: v[0],
-                    active: !has_visible_panel
-                )
-                has_visible_panel = true
-              end
-              return example_switcher if example_switcher.panels.size.positive?
+              content = <<~HEREDOC
+                <pre class="pre-wrap language-json #{@theme_light ? 'Vlt-prism--dark' : ''} Vlt-prism--copy-disabled"><code>#{response}</code></pre>
+              HEREDOC
+
+              example_switcher.add_content(
+                title: v[0].titleize,
+                content: content,
+                tab_id: v[0],
+                active: !has_visible_panel
+              )
+              has_visible_panel = true
             end
-
+            return example_switcher if example_switcher.panels.size.positive?
           end
 
           def handle_all_of(schema)

--- a/lib/nexmo/oas/renderer/views/open_api/_response_tabs.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_response_tabs.erb
@@ -14,32 +14,3 @@
 %>
 
 <%= erb *switcher.render %>
-
-<%
-  # If there are any examples, show them
-  examples = response.raw['content'][format]['examples']
-  if content == :responses && format == "application/json" && examples
-    example_switcher = Nexmo::OAS::Renderer::Presenters::ContentSwitcher.new(label: "Response Example", format: format, force_type: 'dropdown', theme_light: @theme_light)
-
-    examples.each_with_index do |v,k|
-      response = JSON.neat_generate(v[1], {
-                      wrap: true,
-                      after_colon: 1,
-                  })
-
-      content = <<~HEREDOC
-        <pre class="pre-wrap language-json #{@theme_light ? 'Vlt-prism--dark' : ''} Vlt-prism--copy-disabled"><code>#{response}</code></pre>
-      HEREDOC
-
-
-      example_switcher.add_content(
-        title: v[0].titleize,
-        content: content,
-        tab_id: v[0],
-        active: k == 0
-      )
-    end
-  end
-%>
-
-<%= erb *example_switcher.render if example_switcher %>

--- a/lib/nexmo/oas/renderer/views/open_api/_response_tabs.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_response_tabs.erb
@@ -4,13 +4,42 @@
   switcher = Nexmo::OAS::Renderer::Presenters::ContentSwitcher.new(label: "Response Example", format: format, force_type: tabs.switcher, theme_light: @theme_light)
 
   tabs.tab_links.each_with_index do |v,k|
-     switcher.add_content(
-       title: v.content,
-       content: (erb *tabs.tab_panels[k].content),
-       tab_id: v.data_tab_link,
-       active: k == 0
-     )
+    switcher.add_content(
+      title: v.content,
+      content: (erb *tabs.tab_panels[k].content),
+      tab_id: v.data_tab_link,
+      active: k == 0
+    )
   end
 %>
 
 <%= erb *switcher.render %>
+
+<%
+  # If there are any examples, show them
+  examples = response.raw['content'][format]['examples']
+  if content == :responses && format == "application/json" && examples
+    example_switcher = Nexmo::OAS::Renderer::Presenters::ContentSwitcher.new(label: "Response Example", format: format, force_type: 'dropdown', theme_light: @theme_light)
+
+    examples.each_with_index do |v,k|
+      response = JSON.neat_generate(v[1], {
+                      wrap: true,
+                      after_colon: 1,
+                  })
+
+      content = <<~HEREDOC
+        <pre class="pre-wrap language-json #{@theme_light ? 'Vlt-prism--dark' : ''} Vlt-prism--copy-disabled"><code>#{response}</code></pre>
+      HEREDOC
+
+
+      example_switcher.add_content(
+        title: v[0].titleize,
+        content: content,
+        tab_id: v[0],
+        active: k == 0
+      )
+    end
+  end
+%>
+
+<%= erb *example_switcher.render if example_switcher %>

--- a/lib/nexmo/oas/renderer/views/open_api/content_switcher/_dropdown.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/content_switcher/_dropdown.erb
@@ -1,5 +1,7 @@
 <div class="Vlt-dropdown Vlt-dropdown--full-width">
-  <div class="Vlt-dropdown__trigger Vlt-dropdown__trigger--btn"><button class="Vlt-btn Vlt-btn--<%= (theme_light ? "secondary" : "tertiary") %>"><%= label %>: <span class="Vlt-dropdown__selection"><%= panels[0]['title'] %></span></button></div>
+  <div class="Vlt-dropdown__trigger Vlt-dropdown__trigger--btn"><button class="Vlt-btn Vlt-btn--<%= (theme_light ? "secondary" : "tertiary") %>">
+    <%= label ? "#{label}: " : ""%><span class="Vlt-dropdown__selection"><%= panels[0]['title'] %></span>
+  </button></div>
   <div class="Vlt-dropdown__panel">
     <div data-tab-content="<%= switcher.id %>" class="Vlt-dropdown__panel__content">
       <% panels.each do |panel| %>

--- a/samples/verify.yml
+++ b/samples/verify.yml
@@ -1,0 +1,1222 @@
+openapi: 3.0.3
+servers:
+  - url: "https://api.nexmo.com/verify"
+info:
+  title: Verify API
+  version: 1.1.4
+  description: >-
+    The Verify API helps you to implement 2FA (two-factor authentication) in your applications.
+    This is useful for:
+
+
+    * Protecting against spam, by preventing spammers from creating multiple accounts
+
+    * Monitoring suspicious activity, by forcing an account user to verify ownership of a number
+
+    * Ensuring that you can reach your users at any time because you have their correct phone number
+
+    More information is available at <https://developer.nexmo.com/verify>
+  contact:
+    name: Vonage DevRel
+    email: devrel@vonage.com
+    url: "https://developer.nexmo.com/"
+  termsOfService: "https://www.nexmo.com/terms-of-use"
+  license:
+    name: The MIT License (MIT)
+    url: "https://opensource.org/licenses/MIT"
+externalDocs:
+  description: "More information on the Verify product on our Developer Portal"
+  url: "https://developer.nexmo.com/verify"
+paths:
+  "/{format}":
+    post:
+      operationId: verifyRequest
+      summary: Request a Verification
+      description: >-
+        Use Verify request to generate and send a PIN to your user:
+
+
+        1. Create a request to send a verification code to your user.
+
+
+        2. Check the `status` field in the response to ensure that your request
+        was successful (zero is success).
+
+
+        3. Use the `request_id` field in the response for the Verify check.
+
+
+        *Note that this endpoint is available by `GET` request as well as `POST`.*
+      parameters:
+        - $ref: "#/components/parameters/format"
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - api_key
+                - api_secret
+                - number
+                - brand
+              properties:
+                api_key:
+                  $ref: "#/components/schemas/api_key"
+                api_secret:
+                  $ref: "#/components/schemas/api_secret"
+                number:
+                  type: string
+                  description: >-
+                    The mobile or landline phone number to verify. Unless you are
+                    setting `country` explicitly, this number must be in
+                    [E.164](https://en.wikipedia.org/wiki/E.164) format.
+                  example: "447700900000"
+                country:
+                  description: >-
+                    If you do not provide `number` in international format or you are not
+                    sure if `number` is correctly formatted, specify the two-character country
+                    code in `country`. Verify will then format the number for you.
+                  type: string
+                  example: GB
+                brand:
+                  description: >-
+                    An 18-character alphanumeric string you can use to personalize the verification
+                    request SMS body, to help users identify your company or application name.
+                    For example: "Your `Acme Inc` PIN is ..."
+                  type: string
+                  maxLength: 18
+                  example: Acme Inc
+                sender_id:
+                  description: >-
+                    An 11-character alphanumeric string that represents the [identity of the sender](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id)
+                    of the verification request. Depending on the destination of the phone number you are sending the verification SMS to,
+                    restrictions might apply.
+                  type: string
+                  maxLength: 11
+                  default: VERIFY
+                  example: ACME
+                code_length:
+                  description: The length of the verification code.
+                  type: integer
+                  enum:
+                    - 4
+                    - 6
+                  default: 4
+                  example: 6
+                lg:
+                  description: >-
+                    By default, the SMS or text-to-speech (TTS) message is generated in
+                    the locale that matches the `number`. For example, the text message
+                    or TTS message for a `33*` number is sent in French. Use this
+                    parameter to explicitly control the language used for the Verify
+                    request. A list of languages is available: <https://developer.nexmo.com/verify/guides/verify-languages>
+                  example: en-us
+                  type: string
+                  default: en-us
+                  enum:
+                    - ar-xa
+                    - cs-cz
+                    - cy-cy
+                    - cy-gb
+                    - da-dk
+                    - de-de
+                    - el-gr
+                    - en-au
+                    - en-gb
+                    - en-in
+                    - en-us
+                    - es-es
+                    - es-mx
+                    - es-us
+                    - fi-fi
+                    - fil-ph
+                    - fr-ca
+                    - fr-fr
+                    - hi-in
+                    - hu-hu
+                    - id-id
+                    - is-is
+                    - it-it
+                    - ja-jp
+                    - ko-kr
+                    - nb-no
+                    - nl-nl
+                    - pl-pl
+                    - pt-br
+                    - pt-pt
+                    - ro-ro
+                    - ru-ru
+                    - sv-se
+                    - th-th
+                    - tr-tr
+                    - vi-vn
+                    - yue-cn
+                    - zh-cn
+                    - zh-tw
+                pin_expiry:
+                  description: >-
+                    How long the generated verification code is valid for, in seconds.
+                    When you specify both `pin_expiry` and `next_event_wait` then
+                    `pin_expiry` must be an integer multiple of `next_event_wait`
+                    otherwise `pin_expiry` is defaulted to equal next_event_wait. See
+                    [changing the event
+                    timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
+                  type: integer
+                  minimum: 60
+                  maximum: 3600
+                  default: 300
+                  example: 240
+                next_event_wait:
+                  description: >-
+                    Specifies the wait time in seconds between attempts to deliver the
+                    verification code.
+                  type: integer
+                  minimum: 60
+                  maximum: 900
+                  default: 300
+                  example: 120
+                workflow_id:
+                  description: >-
+                    Selects the predefined sequence of SMS and TTS (Text To Speech)
+                    actions to use in order to convey the PIN to your user. For example,
+                    an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
+                    all workflows and their associated ids, please visit the [developer
+                    portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
+                  type: integer
+                  default: 1
+                  enum:
+                    - 1
+                    - 2
+                    - 3
+                    - 4
+                    - 5
+                    - 6
+                    - 7
+                  example: 4
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: Request was started
+                  value:
+                    request_id: abcdef0123456789abcdef0123456789
+                    status: "0"
+
+                throttled:
+                  summary: Request limit exceeded
+                  value:
+                    status: "1"
+                    error_text: Throttled
+
+                missing-param:
+                  summary: Missing a parameter
+                  value:
+                    status: "2"
+                    error_text: Missing api_key
+
+                invalid-param:
+                  summary: Invalid parameter
+                  value:
+                    status: "3"
+                    error_text: Invalid value for number
+
+                invalid-creds:
+                  summary: Invalid credentials
+                  value:
+                    status: "4"
+                    error_text: Invalid credentials were provided
+
+                internal-error:
+                  summary: Internal Error
+                  value:
+                    status: "5"
+                    error_text: Internal Error
+
+                cannot-process:
+                  summary: Unable to process message
+                  value:
+                    status: "6"
+                    error_text: "The Vonage platform was unable to process this message for the following reason: The request could not be routed."
+
+                blacklist:
+                  summary: Blacklisted number
+                  value:
+                    status: "7"
+                    error_text: The number you are trying to verify is blacklisted for verification.
+
+                account-disabled:
+                  summary: Account is barred
+                  value:
+                    status: "8"
+                    error_text: The api_key you supplied is for an account that has been barred from submitting messages.
+
+                quota-exceeded:
+                  summary: Quota exceeded
+                  value:
+                    status: "9"
+                    error_text: Partner quota exceeded
+
+                concurrent:
+                  summary: Concurrent verifications
+                  value:
+                    request_id: abcdef0123456789abcdef0123456789
+                    status: "10"
+                    error_text: Concurrent verifications to the same number are not allowed
+
+                rejected:
+                  summary: Rejected
+                  value:
+                    status: "15"
+                    error_text: The destination number is not in a supported network
+
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/requestResponse"
+                  - $ref: "#/components/schemas/requestErrorResponse"
+            text/xml:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/requestResponse"
+                  - $ref: "#/components/schemas/requestErrorResponse"
+
+  "/check/{format}":
+    post:
+      description: >-
+        Use Verify check to confirm that the PIN you received from your user matches the one sent by
+        Vonage in your Verify request.
+
+
+        1. Send the verification `code` that your user supplied, with the corresponding `request_id` from the Verify request.
+
+        2. Check the `status` of the response to determine if the code the user supplied matches the one sent by Vonage.
+
+
+        *Note that this endpoint is available by `GET` request as well as `POST`.*
+      operationId: verifyCheck
+      summary: Verify Check
+      parameters:
+        - $ref: "#/components/parameters/format"
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - api_key
+                - api_secret
+                - request_id
+                - code
+              properties:
+                api_key:
+                  $ref: "#/components/schemas/api_key"
+                api_secret:
+                  $ref: "#/components/schemas/api_secret"
+                request_id:
+                  description: >-
+                    The Verify request to check. This is the
+                    `request_id` you received in the response to the Verify request.
+                  type: string
+                  maxLength: 32
+                  example: abcdef0123456789abcdef0123456789
+                code:
+                  description: The verification code entered by your user.
+                  type: string
+                  minLength: 4
+                  maxLength: 6
+                  example: "1234"
+                ip_address:
+                  description: >-
+                    (This field is no longer used)
+                  type: string
+                  example: 123.0.0.255
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: The supplied code is correct for this request. Verification successful.
+                  value:
+                    request_id: abcdef0123456789abcdef0123456789
+                    event_id: "0A00000012345678"
+                    status: "0"
+                    price: "0.10000000"
+                    currency: EUR
+                    estimated_price_messages_sent: "0.03330000"
+
+                throttled:
+                  summary: Request limit exceeded
+                  value:
+                    status: "1"
+                    error_text: Throttled
+
+                missing-param:
+                  summary: Missing a parameter
+                  value:
+                    status: "2"
+                    error_text: Missing api_key
+
+                invalid-param:
+                  summary: Invalid parameter
+                  value:
+                    status: "3"
+                    error_text: "Invalid value for param: request_id"
+
+                invalid-creds:
+                  summary: Invalid credentials
+                  value:
+                    status: "4"
+                    error_text: Bad credentials
+
+                internal-error:
+                  summary: Internal Error
+                  value:
+                    status: "5"
+                    error_text: Internal Error
+
+                unknown-requestid:
+                  summary: "This request_id is unknown or inactive"
+                  value:
+                    status: "6"
+                    error_text: "The Vonage platform was unable to process this message for the following reason: Request 'abcdef0123456789abcdef0123456789' was not found or it has been verified already."
+
+                incorrect-code:
+                  summary: PIN code is incorrect
+                  value:
+                    status: "16"
+                    error_text: The code inserted does not match the expected value
+
+                too-many-fails:
+                  summary: Too many incorrect codes
+                  value:
+                    status: "17"
+                    error_text: The wrong code was provided too many times. Request terminated
+
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/checkResponse"
+                  - $ref: "#/components/schemas/checkErrorResponse"
+            text/xml:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/checkResponse"
+                  - $ref: "#/components/schemas/checkErrorResponse"
+
+  "/search/{format}":
+    get:
+      description: >-
+        Use Verify search to check the status of past or current verification requests:
+
+
+        1. Send a Verify search request containing the `request_id`s of the
+        verification requests you are interested in.
+
+        2. Use the `status` of each verification request in the `checks` array of the response object to determine the outcome.
+
+
+        *Note that this endpoint is available by `POST` request as well as `GET`.*
+      operationId: verifySearch
+      summary: Verify Search
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/api_key"
+        - $ref: "#/components/parameters/api_secret"
+        - name: request_id
+          required: false
+          in: query
+          description: The `request_id` you received in the Verify Request Response.
+          schema:
+            type: string
+          example: abcdef0123456789abcdef0123456789
+        - name: request_ids
+          required: false
+          in: query
+          description: >-
+            More than one `request_id`. Each `request_id` is a new parameter in
+            the Verify Search request.
+          schema:
+            type: array
+            items:
+              type: string
+              example: abcdef0123456789abcdef0123456789
+            maxItems: 10
+          style: form
+          explode: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: The request was found
+                  value:
+                    request_id: abcdef0123456789abcdef0123456789
+                    account_id: abcdef01
+                    number: "447700900000"
+                    sender_id: verify
+                    date_submitted: "2020-01-01 12:00:00"
+                    date_finalized: "2020-01-01 12:00:00"
+                    checks:
+                      [
+                        {
+                          date_received: "2020-01-01 12:00:00",
+                          code: "1111",
+                          status: INVALID,
+                          ip_address: "",
+                        },
+                        {
+                          date_received: "2020-01-01 12:02:00",
+                          code: "1234",
+                          status: VALID,
+                          ip_address: "",
+                        },
+                      ]
+                    first_event_date: "2020-01-01 12:00:00"
+                    last_event_date: "2020-01-01 12:00:00"
+                    price: "0.1000000"
+                    currency: EUR
+                    status: SUCCESS
+                    estimated_price_messages_sent: "0.06660000"
+                    events:
+                      [
+                        { id: 0A00000012345678, type: sms },
+                        { id: 0A00000012345679, type: sms },
+                      ]
+
+                throttled:
+                  summary: Request limit exceeded
+                  value:
+                    status: "1"
+                    error_text: Throttled
+
+                missing-param:
+                  summary: Missing a parameter
+                  value:
+                    status: "2"
+                    error_text: Missing api_key
+
+                invalid-param:
+                  summary: Invalid parameter
+                  value:
+                    status: "3"
+                    error_text: "Invalid value for param: request_id"
+
+                invalid-creds:
+                  summary: Invalid credentials
+                  value:
+                    status: "4"
+                    error_text: Bad credentials
+
+                internal-error:
+                  summary: Internal Error
+                  value:
+                    status: "5"
+                    error_text: Internal Error
+
+                not-found:
+                  summary: Request not found (this also occurs immediately after completion, wait 60 seconds and try again)
+                  value:
+                    status: "101"
+                    error_text: No response found
+
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/searchResponse"
+                  - $ref: "#/components/schemas/searchErrorResponse"
+            text/xml:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/searchResponse"
+                  - $ref: "#/components/schemas/searchErrorResponse"
+
+  "/control/{format}":
+    post:
+      description: |-
+        Control the progress of your Verify requests. To cancel an existing Verify request, or to trigger the next verification event:
+
+
+        1. Send a Verify control request with the appropriate command (`cmd`) for what you want to achieve.
+
+        2. Check the `status` in the response.
+
+
+        *Note that this endpoint is available by `GET` request as well as `POST`.*
+      operationId: verifyControl
+      summary: Verify Control
+      parameters:
+        - $ref: "#/components/parameters/format"
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - api_key
+                - api_secret
+                - request_id
+                - cmd
+              properties:
+                api_key:
+                  $ref: "#/components/schemas/api_key"
+                api_secret:
+                  $ref: "#/components/schemas/api_secret"
+                request_id:
+                  description: "The `request_id` you received in the response to the Verify request."
+                  type: string
+                  example: abcdef0123456789abcdef0123456789
+                cmd:
+                  description: >-
+                    The possible commands are `cancel` to request cancellation of
+                    the verification process, or `trigger_next_event` to advance 
+                    to the next verification event (if any).
+                    Cancellation is only possible 30 seconds after the start of the
+                    verification request and before the second event (either TTS or SMS)
+                    has taken place.
+                  type: string
+                  enum:
+                    - cancel
+                    - trigger_next_event
+                  example: cancel
+
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              examples:
+                success-cancel:
+                  summary: The request has been cancelled
+                  value:
+                    status: "0"
+                    command: cancel
+
+                success-trigger:
+                  summary: The next event has been triggered
+                  value:
+                    status: "0"
+                    command: trigger_next_event
+
+                throttled:
+                  summary: Request limit exceeded
+                  value:
+                    status: "1"
+                    error_text: Throttled
+
+                missing-param:
+                  summary: Missing a parameter
+                  value:
+                    status: "2"
+                    error_text: Missing api_key
+
+                invalid-param:
+                  summary: Invalid parameter
+                  value:
+                    status: "3"
+                    error_text: "Invalid value for param: request_id"
+
+                invalid-creds:
+                  summary: Invalid credentials
+                  value:
+                    status: "4"
+                    error_text: Bad credentials
+
+                internal-error:
+                  summary: Internal Error
+                  value:
+                    status: "5"
+                    error_text: Internal Error
+
+                cancel-early:
+                  summary: Cancellation requested less than 30 seconds into the request
+                  value:
+                    status: "19"
+                    error_text: "Verification request ['abcdef0123456789abcdef0123456789'] can't be cancelled within the first 30 seconds."
+
+                cancel-late:
+                  summary: Cancellation requested after too many retry attempts
+                  value:
+                    status: "19"
+                    error_text: "Verification request  ['abcdef0123456789abcdef0123456789'] can't be cancelled now. Too many attempts to re-deliver have already been made."
+
+                trigger-end:
+                  summary: No more events to trigger
+                  value:
+                    status: "19"
+                    error_text: "No more events are left to execute for the request ['abcdef0123456789abcdef0123456789']"
+
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/controlResponse"
+                  - $ref: "#/components/schemas/controlErrorResponse"
+            text/xml:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/controlResponse"
+                  - $ref: "#/components/schemas/controlErrorResponse"
+  "/psd2/{format}":
+    post:
+      operationId: verifyRequestWithPSD2
+      summary: PSD2 (Payment Services Directive 2) Request
+      description: >-
+        Use Verify request to generate and send a PIN to your user to authorize a payment:
+
+        1. Create a request to send a verification code to your user.
+
+        2. Check the `status` field in the response to ensure that your request
+        was successful (zero is success).
+
+        3. Use the `request_id` field in the response for the Verify check.
+
+        (Please note that XML format is not supported for the Payment Services Directive endpoint at this time.)
+
+      parameters:
+        - $ref: "#/components/parameters/format"
+
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - api_key
+                - api_secret
+                - number
+                - payee
+                - amount
+              properties:
+                api_key:
+                  $ref: "#/components/schemas/api_key"
+                api_secret:
+                  $ref: "#/components/schemas/api_secret"
+                number:
+                  type: string
+                  description: >-
+                    The mobile or landline phone number to verify. Unless you are
+                    setting `country` explicitly, this number must be in
+                    [E.164](https://en.wikipedia.org/wiki/E.164) format.
+                  example: "447700900000"
+                country:
+                  description: >-
+                    If you do not provide `number` in international format or you are not
+                    sure if `number` is correctly formatted, specify the two-character country
+                    code in `country`. Verify will then format the number for you.
+                  type: string
+                  example: GB
+                payee:
+                  description: >-
+                    An alphanumeric string to indicate to the user the name of the recipient
+                    that they are confirming a payment to.
+                  type: string
+                  maxLength: 18
+                  example: Acme Inc
+                amount:
+                  description: >-
+                    The decimal amount of the payment to be confirmed, in Euros
+                  type: number
+                  format: float
+                  example: "48.00"
+                code_length:
+                  description: The length of the verification code.
+                  type: integer
+                  enum:
+                    - 4
+                    - 6
+                  default: 4
+                  example: 6
+                lg:
+                  description: >-
+                    By default, the SMS or text-to-speech (TTS) message is generated in
+                    the locale that matches the `number`. For example, the text message
+                    or TTS message for a `33*` number is sent in French. Use this
+                    parameter to explicitly control the language used.
+
+                    *Note: Voice calls in English for `bg-bg`, `ee-et`, `ga-ie`, `lv-lv`, `lt-lt`, `mt-mt`, `sk-sk`, `sk-si`
+                  example: es-es
+                  type: string
+                  default: en-gb
+                  enum:
+                    - en-gb
+                    - bg-bg
+                    - cs-cz
+                    - da-dk
+                    - de-de
+                    - ee-et
+                    - el-gr
+                    - es-es
+                    - fi-fi
+                    - fr-fr
+                    - ga-ie
+                    - hu-hu
+                    - it-it
+                    - lv-lv
+                    - lt-lt
+                    - mt-mt
+                    - nl-nl
+                    - pl-pl
+                    - sk-sk
+                    - sl-si
+                    - sv-se
+                pin_expiry:
+                  description: >-
+                    How long the generated verification code is valid for, in seconds.
+                    When you specify both `pin_expiry` and `next_event_wait` then
+                    `pin_expiry` must be an integer multiple of `next_event_wait`
+                    otherwise `pin_expiry` is defaulted to equal next_event_wait. See
+                    [changing the event
+                    timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
+                  type: integer
+                  minimum: 60
+                  maximum: 3600
+                  default: 300
+                  example: 240
+                next_event_wait:
+                  description: >-
+                    Specifies the wait time in seconds between attempts to deliver the
+                    verification code.
+                  type: integer
+                  minimum: 60
+                  maximum: 900
+                  default: 300
+                  example: 120
+                workflow_id:
+                  description: >-
+                    Selects the predefined sequence of SMS and TTS (Text To Speech)
+                    actions to use in order to convey the PIN to your user. For example,
+                    an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
+                    all workflows and their associated ids, please visit the [developer
+                    portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
+                  type: integer
+                  default: 1
+                  enum:
+                    - 1
+                    - 2
+                    - 3
+                    - 4
+                    - 5
+                    - 6
+                    - 7
+                  example: 4
+
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/requestResponse"
+                  - $ref: "#/components/schemas/requestErrorResponse"
+components:
+  parameters:
+    format:
+      name: format
+      required: true
+      in: path
+      description: The response format.
+      schema:
+        type: string
+        enum:
+          - json
+          - xml
+      example: json
+
+    api_key:
+      name: api_key
+      required: true
+      in: query
+      schema:
+        $ref: "#/components/schemas/api_key"
+
+    api_secret:
+      name: api_secret
+      required: true
+      in: query
+      schema:
+        $ref: "#/components/schemas/api_secret"
+
+  schemas:
+    api_key:
+      type: string
+      description: >-
+        You can find your API key in your [account
+        dashboard](https://dashboard.nexmo.com)
+      example: "abcd1234"
+
+    api_secret:
+      type: string
+      description: >-
+        You can find your API secret in your [account
+        dashboard](https://dashboard.nexmo.com)
+      example: "Sup3rS3cr3t!!"
+
+    estimated_price_messages_sent:
+      type: string
+      description: |
+        This field may not be present, depending on your pricing model. The
+        value indicates the cost (in EUR) of the calls made and messages sent
+        for the verification process. This value may be updated during and
+        shortly after the request completes because user input events can
+        overlap with message/call events. When this field is present, the total
+        cost of the verification is the sum of this field and the `price` field.
+      example: "0.03330000"
+    requestResponse:
+      type: object
+      description: Success
+      xml:
+        name: verify_response
+      properties:
+        request_id:
+          type: string
+          description: >-
+            The unique ID of the Verify request. You need this
+            `request_id` for the Verify check.
+          maxLength: 32
+          example: "abcdef0123456789abcdef0123456789"
+        status:
+          type: string
+          description: "Indicates the outcome of the request; zero is success"
+          example: "0"
+    requestErrorResponse:
+      type: object
+      description: Error
+      xml:
+        name: verify_response
+      properties:
+        request_id:
+          type: string
+          description: >-
+            The unique ID of the Verify request. This may be blank in an error situation
+          maxLength: 32
+          example: ""
+        status:
+          type: string
+          example: "2"
+          enum:
+            - "0"
+            - "1"
+            - "2"
+            - "3"
+            - "4"
+            - "5"
+            - "6"
+            - "7"
+            - "8"
+            - "9"
+            - "10"
+            - "15"
+            - "20"
+          description: |
+            Code | Text | Description
+            -- | -- | --
+            0 | Success | The request was successfully accepted by Vonage.
+            1 | Throttled | You are trying to send more than the maximum of 30 requests per second.
+            2 | Your request is incomplete and missing the mandatory parameter `$parameter` | The stated parameter is missing.
+            3 | Invalid value for parameter `$parameter` | Invalid value for parameter. If you see Facility not allowed in the error text, check that you are using the correct Base URL in your request.
+            4 | Invalid credentials were provided | The supplied API key or secret in the request is either invalid or disabled.
+            5 | Internal Error | An error occurred processing this request in the Cloud Communications Platform.
+            6 | The Vonage platform was unable to process this message for the following reason: `$reason` | The request could not be routed.
+            7 | The number you are trying to verify is blacklisted for verification. |
+            8 | The api_key you supplied is for an account that has been barred from submitting messages. |
+            9 | Partner quota exceeded | Your account does not have sufficient credit to process this request.
+            10 | Concurrent verifications to the same number are not allowed |
+            15 | The destination number is not in a supported network | The request has been rejected. Find out more about this error in the [Knowledge Base](https://help.nexmo.com/hc/en-us/articles/360018406532-Verify-On-demand-Service-to-High-Risk-Countries)
+            20 | This account does not support the parameter: pin_code. | Only certain accounts have the ability to set the `pin_code`. Please contact your account manager for more information.
+        error_text:
+          type: string
+          description: "If `status` is non-zero, this explains the error encountered."
+          example: "Your request is incomplete and missing the mandatory parameter `number`"
+    checkResponse:
+      type: object
+      description: Success
+      properties:
+        request_id:
+          type: string
+          description: >-
+            The `request_id` that you received in the response to the Verify request and
+            used in the Verify check request.
+          example: abcdef0123456789abcdef0123456789
+        event_id:
+          type: string
+          description: The ID of the verification event, such as an SMS or TTS call.
+          example: 0A00000012345678
+        status:
+          type: string
+          description: >-
+            A value of `0` indicates that your user entered the correct code. If
+            it is non-zero, check the `error_text`.
+          example: "0"
+        price:
+          type: string
+          description: The cost incurred for this request.
+          example: "0.10000000"
+        currency:
+          type: string
+          description: The currency code.
+          example: EUR
+        estimated_price_messages_sent:
+          $ref: "#/components/schemas/estimated_price_messages_sent"
+      xml:
+        name: verify_response
+    checkErrorResponse:
+      type: object
+      description: Error
+      properties:
+        request_id:
+          type: string
+          description: >-
+            The `request_id` that you received in the response to the Verify request and
+            used in the Verify check request.
+          example: abcdef0123456789abcdef0123456789
+        status:
+          type: string
+          example: "16"
+          enum:
+            - "0"
+            - "1"
+            - "2"
+            - "3"
+            - "4"
+            - "5"
+            - "6"
+            - "16"
+            - "17"
+          description: |
+            Code | Text | Description
+            -- | -- | --
+            0 | Success | The request was successfully accepted by Vonage.
+            1 | Throttled | You are trying to send more than the maximum of 30 requests per second.
+            2 | Your request is incomplete and missing the mandatory parameter `$parameter` | The stated parameter is missing.
+            3 | Invalid value for parameter `$parameter` | Invalid value for parameter. If you see Facility not allowed in the error text, check that you are using the correct Base URL in your request.
+            4 | Invalid credentials were provided | The supplied API key or secret in the request is either invalid or disabled.
+            5 | Internal Error | An error occurred processing this request in the Cloud Communications Platform.
+            6 | The Vonage platform was unable to process this message for the following reason: `$reason` | The request could not be routed.
+            16 | The code inserted does not match the expected value |
+            17 | The wrong code was provided too many times | You can run Verify check on a specific `request_id` up to three times unless a new verification code is generated. If you check a request more than three times, it is set to FAILED and you cannot check it again.
+        error_text:
+          type: string
+          description: If the `status` is non-zero, this explains the error encountered.
+          example: The code inserted does not match the expected value
+      xml:
+        name: verify_response
+    searchResponse:
+      xml:
+        name: verify_request
+      type: object
+      description: Success
+      properties:
+        request_id:
+          type: string
+          description: >-
+            The `request_id` that you received in the response to the Verify request and
+            used in the Verify search request.
+          example: abcdef0123456789abcdef0123456789
+        account_id:
+          type: string
+          description: The Vonage account ID the request was for.
+          example: abcdef01
+        status:
+          type: string
+          example: IN PROGRESS
+          enum:
+            - IN PROGRESS
+            - SUCCESS
+            - FAILED
+            - EXPIRED
+            - CANCELLED
+          description: |
+            Code | Description
+            -- | --
+            IN PROGRESS | The search is still in progress.
+            SUCCESS | Your user entered a correct verification code.
+            FAILED | Your user entered an incorrect code more than three times.
+            EXPIRED | Your user did not enter a code before the `pin_expiry` time elapsed.
+            CANCELLED | The verification process was cancelled by a Verify control request.
+        number:
+          type: string
+          description: The phone number this verification request was used for.
+          example: "447700900000"
+        price:
+          type: string
+          description: The cost incurred for this verification request.
+          example: "0.10000000"
+        currency:
+          type: string
+          description: The currency code.
+          example: EUR
+        sender_id:
+          type: string
+          description: The `sender_id` you provided in the Verify request.
+          default: verify
+          example: mySenderId
+        date_submitted:
+          type: string
+          description: >-
+            The date and time the verification request was submitted, in the following format YYYY-MM-DD HH:MM:SS.
+          example: "2020-01-01 12:00:00"
+        date_finalized:
+          type: string
+          description: >-
+            The date and time the verification request was completed. This
+            response parameter is in the following format YYYY-MM-DD HH:MM:SS.
+          example: "2020-01-01 12:00:00"
+        first_event_date:
+          type: string
+          description: >-
+            The time the first verification attempt was made, in the
+            following format YYYY-MM-DD HH:MM:SS.
+          example: "2020-01-01 12:00:00"
+        last_event_date:
+          type: string
+          description: >-
+            The time the last verification attempt was made, in the
+            following format YYYY-MM-DD HH:MM:SS.
+          example: "2020-01-01 12:00:00"
+        checks:
+          type: array
+          xml:
+            wrapped: true
+          description: The list of checks made for this verification and their outcomes.
+          items:
+            type: object
+            xml:
+              name: check
+            properties:
+              date_received:
+                type: string
+                description: The date and time this check was received (in the format YYYY-MM-DD HH:MM:SS)
+                example: "2020-01-01 12:00:00"
+              code:
+                type: string
+                description: The code supplied with this check request
+                example: "987654"
+              status:
+                type: string
+                enum:
+                  - VALID
+                  - INVALID
+              ip_address:
+                type: string
+                description: The IP address, if available (this field is no longer used).
+                example: 123.0.0.255
+        events:
+          type: array
+          xml:
+            wrapped: true
+          description: The events that have taken place to verify this number, and their unique identifiers.
+          items:
+            type: object
+            xml:
+              name: event
+            properties:
+              type:
+                type: string
+                enum:
+                  - tts
+                  - sms
+              id:
+                type: string
+        estimated_price_messages_sent:
+          $ref: "#/components/schemas/estimated_price_messages_sent"
+    searchErrorResponse:
+      x-examples:
+        - throttled
+        - missing-param
+      xml:
+        name: verify_request
+      type: object
+      description: Error
+      properties:
+        request_id:
+          type: string
+          description: >-
+            The `request_id` that you received in the response to the Verify request and
+            used in the Verify search request. May be empty in an error situation.
+          example: abcdef0123456789abcdef0123456789
+        status:
+          type: string
+          example: "IN PROGRESS"
+          enum:
+            - IN PROGRESS
+            - FAILED
+            - EXPIRED
+            - CANCELLED
+            - "101"
+          description: |
+            Code | Description
+            -- | --
+            IN PROGRESS | The search is still in progress.
+            SUCCESS | Your user entered a correct verification code.
+            FAILED | Your user entered an incorrect code more than three times.
+            EXPIRED | Your user did not enter a code before the `pin_expiry` time elapsed.
+            CANCELLED | The verification process was cancelled by a Verify control request.
+            101 | You supplied an invalid `request_id`, or the data is not available. Note that for recently-completed requests, there can be a delay of up to 1 minute before the results are available in search.
+        error_text:
+          type: string
+          description: If `status` is not `SUCCESS`, this message explains the issue encountered.
+          example: No response found
+    controlResponse:
+      type: object
+      description: Success
+      xml:
+        name: response
+      properties:
+        status:
+          type: string
+          example: "0"
+          description: |
+            `cmd` | Code | Description
+            -- | -- | --
+            Any | 0 | Success
+        command:
+          type: string
+          description: The `cmd` you sent in the request.
+          enum:
+            - "cancel"
+            - "trigger_next_event"
+          example: "cancel"
+    controlErrorResponse:
+      type: object
+      description: Error
+      xml:
+        name: response
+      properties:
+        status:
+          type: string
+          example: "6"
+          enum:
+            - "0"
+            - "1"
+            - "2"
+            - "3"
+            - "4"
+            - "5"
+            - "6"
+            - "8"
+            - "9"
+            - "19"
+          description: |
+            Code | Text | Description
+            -- | -- | --
+            0 | Success | The request was successfully accepted by Vonage.
+            1 | Throttled | You are trying to send more than the maximum of 30 requests per second.
+            2 | Your request is incomplete and missing the mandatory parameter `$parameter` | The stated parameter is missing.
+            3 | Invalid value for parameter `$parameter` | Invalid value for parameter. If you see Facility not allowed in the error text, check that you are using the correct Base URL in your request.
+            4 | Invalid credentials were provided | The supplied API key or secret in the request is either invalid or disabled.
+            5 | Internal Error | An error occurred processing this request in the Cloud Communications Platform.
+            6 | The Vonage platform was unable to process this message for the following reason: `$reason` | The request could not be routed.
+            8 | The api_key you supplied is for an account that has been barred from submitting messages. |
+            9 | Partner quota exceeded | Your account does not have sufficient credit to process this request.
+            19 | For `cancel`: Either you have not waited at least 30 secs after sending a Verify request before cancelling or Verify has made too many attempts to deliver the verification code for this request and you must now wait for the process to complete. For `trigger_next_event`: All attempts to deliver the verification code for this request have completed and there are no remaining events to advance to.
+        error_text:
+          type: string
+          description: If the `status` is non-zero, this explains the error encountered.
+          example: "The requestId 'abcdef0123456789abcdef' does not exist or its no longer active."

--- a/spec/lib/nexmo/oas/renderer/presenters/response_tab/panel_spec.rb
+++ b/spec/lib/nexmo/oas/renderer/presenters/response_tab/panel_spec.rb
@@ -1,5 +1,6 @@
 require 'nexmo/oas/renderer/presenters/response_tab/panel'
 require 'nexmo/oas/renderer/decorators/response_parser_decorator'
+require 'nexmo/oas/renderer/presenters/content_switcher'
 
 RSpec.describe Nexmo::OAS::Renderer::Presenters::ResponseTab::Panel do
   let(:format) { 'application/json' }

--- a/spec/lib/nexmo/oas/renderer/presenters/response_tabs_spec.rb
+++ b/spec/lib/nexmo/oas/renderer/presenters/response_tabs_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Nexmo::OAS::Renderer::Presenters::ResponseTabs do
 
   describe '#tab_panels' do
     it 'returns instances of ResponseTab::Panel' do
+      expect(response).to receive(:raw).and_return({}).twice
       expect(subject.tab_panels).to all(
         be_an_instance_of(Nexmo::OAS::Renderer::Presenters::ResponseTab::Panel)
       )


### PR DESCRIPTION
This PR adds support for examples when viewing response bodies. See the sample Verify spec to see it live

Examples must be added at the **media type** level, alongside `schema` and an `x-errors` key must be added inside **schema** indicating which errors are used by that schema

![image](https://user-images.githubusercontent.com/59130/97045803-531e1b80-156e-11eb-8c67-62aa1dd91190.png)
