### PR TITLE
Adding Deprecated tagging in renderer

### DIFF
--- a/lib/nexmo/oas/renderer/public/assets/stylesheets/nexmo-oas-renderer.css
+++ b/lib/nexmo/oas/renderer/public/assets/stylesheets/nexmo-oas-renderer.css
@@ -53,6 +53,7 @@
   .oas-wrapper .oas-parameter-description {
     margin-left: 16px; }
   .oas-wrapper .oas-parameter-meta {
+    padding-bottom: 2px;
     border-bottom: 1px solid #ccc;
     margin-bottom: 4px; }
   .oas-wrapper .oas-parameter-nested {

--- a/lib/nexmo/oas/renderer/views/open_api/_parameters.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_parameters.erb
@@ -65,6 +65,12 @@
         <% if parameter.maximum || parameter.raw['maxLength'] %>
           | <span class="constraint">Max:</span> <%= parameter.maximum || parameter.raw['maxLength'] %>
         <% end %>
+        <% if parameter.raw['deprecated'] %>             
+          | <span class="constraint">DEPRECATED</span> <span>: This field has been deprecated. </span>          
+        <% end %>
+        <% if parameter.raw['x-replace-with']%>            
+            <span> <%= 'Please use ' + '<code>'+ parameter.raw['x-replace-with'] + '</code>' + ' instead.' %> </span>
+        <% end %>
       </div>
 
       <%= (parameter.description || parameter.schema['description'] || '').render_markdown %>


### PR DESCRIPTION
Adding handling of `deprecated` oas field. When a field is marked as deprecated the word `DEPRECATED` will appear as a constraint for the field. Also the user has the option of adding a `x-replace-with` field indicating what the field is meant to be replaced with.