### PR TITLE
Pass `request.env` to Rails' renderer.

### DIFF
--- a/lib/nexmo/oas/renderer/helpers/render.rb
+++ b/lib/nexmo/oas/renderer/helpers/render.rb
@@ -15,7 +15,7 @@ module Nexmo
             if args.length > 2
               super
             else
-              ApplicationController.renderer.render(*args)
+              ApplicationController.renderer.new(request.env).render(*args)
             end
           end
         end


### PR DESCRIPTION
This allows Rails' helpers and views to access the request's env
properly instead of the default ones. See https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/renderer.rb#L53