### PR TITLE
Nullable fields should now display as such

### DIFF
--- a/lib/nexmo/oas/renderer/views/open_api/_response_description_parameters.erb
+++ b/lib/nexmo/oas/renderer/views/open_api/_response_description_parameters.erb
@@ -34,7 +34,8 @@
 
       <div class="oas-parameter-description">
         <div class="oas-parameter-meta">
-          <%= parameter['type'] %>
+          <% if parameter['nullable'] %>Nullable <% end %><%= parameter['type'] %>
+
           <% if parameter['type'] == 'array' %>
             <% if parameter['items'] && parameter['items']['type'] %>
               of <%= (parameter['items']['type']) %>s


### PR DESCRIPTION
We do not currently show whether a field is flagged as Nullable, this will now display fields as such. For example:

"Nullable String"